### PR TITLE
make API much more flexible with different types of incoming requests

### DIFF
--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -6,6 +6,7 @@ from formspree import settings, log
 from formspree.utils import unix_time_for_12_months_from_now, next_url
 from flask import url_for, render_template
 from sqlalchemy.sql.expression import delete
+from werkzeug.datastructures import ImmutableMultiDict
 from helpers import HASH, HASHIDS_CODEC, MONTHLY_COUNTER_KEY, http_form_to_dict, referrer_to_path, send_email
 
 CODE_TEMPLATE = '''
@@ -85,13 +86,16 @@ class Form(DB.Model):
         id = HASHIDS_CODEC.decode(random_like_string)[0]
         return cls.query.get(id)
 
-    def send(self, http_form, referrer):
+    def send(self, submitted_data, referrer):
         '''
         Sends form to user's email.
         Assumes sender's email has been verified.
         '''
 
-        data, keys = http_form_to_dict(http_form)
+        if type(submitted_data) is ImmutableMultiDict:
+            data, keys = http_form_to_dict(submitted_data)
+        else:
+            data, keys = submitted_data, submitted_data.keys()
 
         subject = data.get('_subject', 'New submission from %s' % referrer_to_path(referrer))
         reply_to = data.get('_replyto', data.get('email', data.get('Email', None)))

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -83,7 +83,7 @@ def send(email_or_string):
     # If form exists and is confirmed, send email
     # otherwise send a confirmation email
     if form.confirmed:
-        status = form.send(request.form, request.referrer)
+        status = form.send(request.form or request.get_json(), request.referrer)
     else:
         status = form.send_confirmation()
 

--- a/formspree/utils.py
+++ b/formspree/utils.py
@@ -13,11 +13,27 @@ import uuid
 def request_wants_json():
     if request.headers.get('X_REQUESTED_WITH','').lower() == 'xmlhttprequest':
         return True
-    best = request.accept_mimetypes \
-        .best_match(['application/json', 'text/html'])
-    return best == 'application/json' and \
-        request.accept_mimetypes[best] > \
-        request.accept_mimetypes['text/html']
+    if accept_better('json', 'html'):
+        return True
+    if 'json' in request.headers.get('Content-Type', '') and \
+            not accept_better('html', 'json'):
+        return True
+
+
+def accept_better(subject, against):
+    if 'Accept' in request.headers:
+        accept = request.headers['Accept'].lower()
+        try:
+            isub = accept.index(subject)
+        except ValueError:
+            return False
+
+        try:
+            iaga = accept.index(against)
+        except ValueError:
+            return True
+
+        return isub < iaga
 
 
 def jsonerror(code, *args, **kwargs):

--- a/formspree/utils.py
+++ b/formspree/utils.py
@@ -34,6 +34,8 @@ def accept_better(subject, against):
             return True
 
         return isub < iaga
+    else:
+        return False
 
 
 def jsonerror(code, *args, **kwargs):

--- a/tests/formspree_test_case.py
+++ b/tests/formspree_test_case.py
@@ -22,6 +22,8 @@ class FormspreeTestCase(TestCase):
 
         settings.PRESERVE_CONTEXT_ON_EXCEPTION = False
 
+        settings.PRESERVE_CONTEXT_ON_EXCEPTION = False
+
         return create_app()
 
     def setUp(self):

--- a/tests/formspree_test_case.py
+++ b/tests/formspree_test_case.py
@@ -20,6 +20,8 @@ class FormspreeTestCase(TestCase):
         settings.PRESERVE_CONTEXT_ON_EXCEPTION = False
         settings.SQLALCHEMY_DATABASE_URI = os.getenv('TEST_DATABASE_URL')
 
+        settings.PRESERVE_CONTEXT_ON_EXCEPTION = False
+
         return create_app()
 
     def setUp(self):

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -67,19 +67,18 @@ class ContentTypeTestCase(FormspreeTestCase):
             data = {'name': 'bob'}
             data = json.dumps(data) if ct and 'json' in ct else data
 
-            # print 'SENT'
-            # print 'headers', headers
-            # print type(data), data
-            # print '\n'
+            res = self.client.post('/bob@example.com',
+                headers=headers,
+                data=data
+            )
+            check(res)
+
+            # test all combinations again, but with X-Requested-With header
+            # and expect json in all of them
+            headers['X-Requested-With'] = 'XMLHttpRequest'
 
             res = self.client.post('/bob@example.com',
                 headers=headers,
                 data=data
             )
-
-            # print 'GOT'
-            # print res.headers
-            # print res.get_data()
-            # print '\n'
-
-            check(res)
+            isjson(res)

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -2,6 +2,7 @@ import httpretty
 import json
 
 from formspree.forms.models import Form
+from formspree import settings
 from formspree.app import DB
 
 from formspree_test_case import FormspreeTestCase
@@ -57,6 +58,10 @@ class ContentTypeTestCase(FormspreeTestCase):
             (None, 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8', ishtml)
         ]
 
+        # for this test only we will relax this limit.
+        default_limit = settings.MONTHLY_SUBMISSIONS_LIMIT
+        settings.MONTHLY_SUBMISSIONS_LIMIT = len(types)
+
         for ct, acc, check in types:
             headers = {'Referer': 'http://example.com'}
             if ct:
@@ -82,3 +87,6 @@ class ContentTypeTestCase(FormspreeTestCase):
                 data=data
             )
             isjson(res)
+
+        # then we put the default limit back
+        settings.MONTHLY_SUBMISSIONS_LIMIT = default_limit

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -23,19 +23,20 @@ class ContentTypeTestCase(FormspreeTestCase):
 
         def isjson(res):
             try:
-                json.loads(res.get_data())
-                assert(res.mimetype == 'application/json')
-                return True
-            except ValueError:
-                return False
+                d = json.loads(res.get_data())
+                self.assertIsInstance(d, dict)
+                self.assertIn('success', d)
+                self.assertEqual(res.mimetype, 'application/json')
+            except ValueError, e:
+                self.assertFalse(e)
 
         def ishtml(res):
             try:
-                json.loads(res.get_data())
-                return False
+                d = json.loads(res.get_data())
+                self.assertNotIsInstance(d, dict)
             except ValueError:
-                assert(res.mimetype == 'text/html')
-                return True
+                self.assertEqual(res.mimetype, 'text/html')
+                self.assertEqual(res.status_code, 302)
 
         types = [
              # content-type      # accept     # check
@@ -81,15 +82,4 @@ class ContentTypeTestCase(FormspreeTestCase):
             # print res.get_data()
             # print '\n'
 
-            assertion = check(res)
-            self.assertTrue(assertion)
-
-
-
-
-
-
-
-
-
-
+            check(res)

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -1,0 +1,95 @@
+import httpretty
+import json
+
+from formspree.forms.models import Form
+from formspree.app import DB
+
+from formspree_test_case import FormspreeTestCase
+
+class ContentTypeTestCase(FormspreeTestCase):
+
+    @httpretty.activate
+    def test_various_content_types(self):
+        httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
+        r = self.client.post('/bob@example.com',
+            headers = {'Referer': 'http://example.com'},
+            data={'name': 'bob'}
+        )
+        f = Form.query.first()
+        f.confirm_sent = True
+        f.confirmed = True
+        DB.session.add(f)
+        DB.session.commit()
+
+        def isjson(res):
+            try:
+                json.loads(res.get_data())
+                assert(res.mimetype == 'application/json')
+                return True
+            except ValueError:
+                return False
+
+        def ishtml(res):
+            try:
+                json.loads(res.get_data())
+                return False
+            except ValueError:
+                assert(res.mimetype == 'text/html')
+                return True
+
+        types = [
+             # content-type      # accept     # check
+            (None, None, ishtml),
+            ('application/json', 'text/json', isjson),
+            ('application/json', 'application/json', isjson),
+            (None, 'application/json', isjson),
+            (None, 'application/json, text/javascript, */*; q=0.01', isjson),
+            ('application/json', None, isjson),
+            ('application/json', 'application/json, text/plain, */*', isjson),
+            ('application/x-www-form-urlencoded', 'application/json', isjson),
+            ('application/x-www-form-urlencoded', 'application/json, text/plain, */*', isjson),
+            ('application/x-www-form-urlencoded', None, ishtml),
+            (None, 'text/html', ishtml),
+            ('application/json', 'text/html', ishtml),
+            ('application/json', 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8', ishtml),
+            ('application/x-www-form-urlencoded', 'text/html, */*; q=0.01', ishtml),
+            (None, 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8', ishtml)
+        ]
+
+        for ct, acc, check in types:
+            headers = {'Referer': 'http://example.com'}
+            if ct:
+                headers['Content-Type'] = ct
+            if acc:
+                headers['Accept'] = acc
+
+            data = {'name': 'bob'}
+            data = json.dumps(data) if ct and 'json' in ct else data
+
+            # print 'SENT'
+            # print 'headers', headers
+            # print type(data), data
+            # print '\n'
+
+            res = self.client.post('/bob@example.com',
+                headers=headers,
+                data=data
+            )
+
+            # print 'GOT'
+            # print res.headers
+            # print res.get_data()
+            # print '\n'
+
+            assertion = check(res)
+            self.assertTrue(assertion)
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This is a dumb implementation I came up with. It seems to work whenever I test it (after I fixed various quirks and bugs), but there's probably some bug still. Anyway, the present request_wants_json, however, is not foolproof, it is failing and must be changed.

Most Javascript HTTP libraries, superagent, for example, automatically send the data you pass to them in JSON format and set the Content-Type header to application/json, but don't set the Accept header. And I can't imagine a situation in which someone would send an AJAX request like this and expect an HTML response.

Also, Angular automatically sets the Accept header to application/json, text/plain, */*, and I don't know why but Werkzeug parses it in a way that request.accept_mimetypes['application/json'] is 1, but request.accept_mimetypes['text/html'] is also 1, so it fails.

Besides this, I think we need to accept a JSON body when the user wants to send it, it will not hurt anyone or anybody to do it (in Javascript it is many times easier to send a JSON body, as the use cases above prove).