### PR TITLE
show hint with the actual url that is being or must be used for each form.

### DIFF
--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -212,7 +212,7 @@ def forms():
 
         # grab all the forms this user controls
         if current_user.upgraded:
-            forms = current_user.forms.order_by(Form.id.desc()).all()
+            forms = current_user.forms.order_by(Form.host).all()
         else:
             forms = []
 

--- a/formspree/templates/forms/list.html
+++ b/formspree/templates/forms/list.html
@@ -27,7 +27,7 @@
           {{ form.host }}
         {% endif %}
       </td>
-      <td>{{ form.email }}</td>
+      <td><span class="hint--top" data-hint="{{ request.url_root.replace('http://', 'https://') }}{% if form.hash %}{{ form.email }}{% else %}{{ form.hashid }}{% endif %}">{{ form.email }}</span></td>
       <td>
         {% if form.is_new %}
           form never submitted


### PR DESCRIPTION
helps users identify which forms were created automatically by a submission and which were created from the dashboard, in case there are many with the same URL-email combination.