### PR TITLE
automate the bounce deletion process.

### DIFF
--- a/formspree/templates/forms/confirmation_sent.html
+++ b/formspree/templates/forms/confirmation_sent.html
@@ -16,6 +16,12 @@
       >
         <style>.g-recaptcha div { width: auto !important; height: auto !important; }</style>
         <input type="hidden" name="host" value="{{ host }}">
+        {% if request.cookies.get('has_been_notified_of_bounce') %}
+          <label>
+            <input type="checkbox" name="bounce_problem_solved" value="true">
+            I confirm that my mailbox is receiving email correctly
+          </label>
+        {% endif %}
         <script src='https://www.google.com/recaptcha/api.js'></script>
         <div class="g-recaptcha" data-sitekey="{{ config.RECAPTCHA_KEY }}"></div>
         <button type="submit">Resend</button>


### PR DESCRIPTION
If, at the time the user tries to resend the confirmation, we detect that his first confirmation email has bounced, a screen like this is shown:

![mailbox](https://cloud.githubusercontent.com/assets/1653275/12873335/32d11158-cda1-11e5-8bbe-d35673b47c5b.png)

Then, after he goes to his mailbox and verify everything, he comes back and tries to resend confirmation again, then he is presented with the same resend-confirmation + recaptcha screen, however this time there's a checkbox that he can check and confirm that he has verified his mailbox.

![confirm](https://cloud.githubusercontent.com/assets/1653275/12873344/7985cc2e-cda1-11e5-9f2f-96b98a0898dc.png)

The checkbox is shown to whatever user has the cookies that say he has seen the bounce message (first image). The cookie lasts for 4 days. If the checkbox is checked, the server automatically drops the bounce from SendGrid using their API and tries to resend the confirmation.

This removes a lot of the work load from the support team.

You can test it by submitting to some invalid email address on http://formspree-fiatjaf.herokuapp.com/