### PR TITLE
Fix unsecured favicon on the homepage

### DIFF
--- a/formspree/static_pages/views.py
+++ b/formspree/static_pages/views.py
@@ -13,4 +13,4 @@ def page_not_found(e):
     return render_template('error.html', title='Oops, page not found'), 404
 
 def favicon():
-    return redirect(url_for('static', filename='img/favicon.ico'))
+    return redirect(url_for('static', filename='img/favicon.ico', _scheme='https'))


### PR DESCRIPTION
Some users were having the issue where https://formspree.io/favicon.ico redirects to http://formspree.io/static/img/favicon.ico, which caused Chrome to say our website was insecure. This should tell Flask that it should get the favicon from the SSL version