### PR TITLE
Allow for old HTML emails to be sent

### DIFF
--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -8,7 +8,7 @@ import hashlib
 import hashids
 
 HASH = lambda x, y: hashlib.md5(x+y+settings.NONCE_SECRET).hexdigest()
-EXCLUDE_KEYS = ['_gotcha', '_next', '_subject', '_cc']
+EXCLUDE_KEYS = ['_gotcha', '_next', '_subject', '_cc', '_text']
 MONTHLY_COUNTER_KEY = 'monthly_{form_id}_{month}'.format
 HASHIDS_CODEC = hashids.Hashids(alphabet='abcdefghijklmnopqrstuvwxyz',
                                 min_length=8,

--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -8,7 +8,7 @@ import hashlib
 import hashids
 
 HASH = lambda x, y: hashlib.md5(x+y+settings.NONCE_SECRET).hexdigest()
-EXCLUDE_KEYS = ['_gotcha', '_next', '_subject', '_cc', '_text']
+EXCLUDE_KEYS = ['_gotcha', '_next', '_subject', '_cc', '_format']
 MONTHLY_COUNTER_KEY = 'monthly_{form_id}_{month}'.format
 HASHIDS_CODEC = hashids.Hashids(alphabet='abcdefghijklmnopqrstuvwxyz',
                                 min_length=8,

--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -156,7 +156,7 @@ class Form(DB.Model):
         if not overlimit:
             text = render_template('email/form.txt', data=data, host=self.host, keys=keys, now=now)
             # check if the user wants a new or old version of the email
-            if format is "text":
+            if format is 'text':
                 html = render_template('email/text_form.html', data=data, host=self.host, keys=keys, now=now)
             else:
                 html = render_template('email/form.html', data=data, host=self.host, keys=keys, now=now)

--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -106,7 +106,7 @@ class Form(DB.Model):
         cc = data.get('_cc', None)
         next = next_url(referrer, data.get('_next'))
         spam = data.get('_gotcha', None)
-        text_version = data.get('_text', None)
+        format = data.get('_format', None)
 
         # prevent submitting empty form
         if not any(data.values()):
@@ -155,7 +155,8 @@ class Form(DB.Model):
         now = datetime.datetime.utcnow().strftime('%I:%M %p UTC - %d %B %Y')
         if not overlimit:
             text = render_template('email/form.txt', data=data, host=self.host, keys=keys, now=now)
-            if text_version:
+            # check if the user wants a new or old version of the email
+            if format is "text":
                 html = render_template('email/text_form.html', data=data, host=self.host, keys=keys, now=now)
             else:
                 html = render_template('email/form.html', data=data, host=self.host, keys=keys, now=now)

--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -106,6 +106,7 @@ class Form(DB.Model):
         cc = data.get('_cc', None)
         next = next_url(referrer, data.get('_next'))
         spam = data.get('_gotcha', None)
+		text_version = data.get('_text', None)
 
         # prevent submitting empty form
         if not any(data.values()):
@@ -154,7 +155,10 @@ class Form(DB.Model):
         now = datetime.datetime.utcnow().strftime('%I:%M %p UTC - %d %B %Y')
         if not overlimit:
             text = render_template('email/form.txt', data=data, host=self.host, keys=keys, now=now)
-            html = render_template('email/form.html', data=data, host=self.host, keys=keys, now=now)
+			if text_version:
+				html = render_template('email/text_form.html', data=data, host=self.host, keys=keys, now=now)
+			else:
+            	html = render_template('email/form.html', data=data, host=self.host, keys=keys, now=now)
         else:
             if monthly_counter - settings.MONTHLY_SUBMISSIONS_LIMIT > 25:
                 # only send this overlimit notification for the first 25 overlimit emails

--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -106,7 +106,7 @@ class Form(DB.Model):
         cc = data.get('_cc', None)
         next = next_url(referrer, data.get('_next'))
         spam = data.get('_gotcha', None)
-		text_version = data.get('_text', None)
+        text_version = data.get('_text', None)
 
         # prevent submitting empty form
         if not any(data.values()):
@@ -155,10 +155,10 @@ class Form(DB.Model):
         now = datetime.datetime.utcnow().strftime('%I:%M %p UTC - %d %B %Y')
         if not overlimit:
             text = render_template('email/form.txt', data=data, host=self.host, keys=keys, now=now)
-			if text_version:
-				html = render_template('email/text_form.html', data=data, host=self.host, keys=keys, now=now)
-			else:
-            	html = render_template('email/form.html', data=data, host=self.host, keys=keys, now=now)
+            if text_version:
+                html = render_template('email/text_form.html', data=data, host=self.host, keys=keys, now=now)
+            else:
+                html = render_template('email/form.html', data=data, host=self.host, keys=keys, now=now)
         else:
             if monthly_counter - settings.MONTHLY_SUBMISSIONS_LIMIT > 25:
                 # only send this overlimit notification for the first 25 overlimit emails

--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -156,7 +156,7 @@ class Form(DB.Model):
         if not overlimit:
             text = render_template('email/form.txt', data=data, host=self.host, keys=keys, now=now)
             # check if the user wants a new or old version of the email
-            if format is 'text':
+            if format == 'text':
                 html = render_template('email/text_form.html', data=data, host=self.host, keys=keys, now=now)
             else:
                 html = render_template('email/form.html', data=data, host=self.host, keys=keys, now=now)

--- a/formspree/templates/email/text_form.html
+++ b/formspree/templates/email/text_form.html
@@ -1,0 +1,24 @@
+<p>Hey there,</p>
+
+</p>Someone just submitted your form on {{host}}.</p>
+
+<p>Here's what they had to say:</p>
+
+<hr style="color: #359173; border: 1px dashed #359173;">
+
+<table border="0" width="100%">
+    {% for k in keys %}
+        <tr>
+            <td align="right" valign="top" width="70" style="padding: 5px 5px 5px 0;"><strong>{{k}}:</strong> </td>
+            <td align="left" valign="top" width="*" style="padding: 5px 5px 5px;">
+              <pre style="margin: 0; font-family: inherit;">{{data.get(k,'')}}</pre>
+            </td>
+        </tr>
+    {% endfor %}
+</table>
+
+<small style="margin-left: 10px; font-size: 10px;">This form was submitted at {{ now }}.</small>
+
+<hr style="color: #359173; border: 1px dashed #359173;" />
+
+<p>You are receiving this because you confirmed this email address on <a href="{{config.SERVICE_URL}}">{{config.SERVICE_NAME}}</a>. If you don't remember doing that, or no longer wish to receive these emails, please remove the form on {{host}} or send an email to {{config.CONTACT_EMAIL}}.</p>

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -160,6 +160,14 @@
 
       <div class="container narrow block">
             <div class="col-1-1">
+                <h4><span class="code">_format</span></h4>
+                <p>Add this to your form will allow for you to receive plain text versions of emails for form submissions.</p>
+                <p><input type="text" class="code" value='<input type="text" name="_format" value="text" style="display:none" />'></p>
+            </div>
+      </div>
+
+      <div class="container narrow block">
+            <div class="col-1-1">
                 <h4>Using AJAX</h4>
                 <p>You can use {{config.SERVICE_NAME}} via AJAX. This even works cross-origin. The trick is to set the <span class="code">Accept</span> header to <span class="code">application/json</span>. If you're using jQuery this can be done like so:
                 <p class="card code">


### PR DESCRIPTION
**Changes proposed in this pull request:**

* Users can choose what version of the HTML emails they want.

**Have you made sure to add:**
- [x] Tests
- [ ] Documentation

Have not added tests, but perhaps some should be added? It's a pretty small change.

**Any Additional Information**

In order for a user to choose the old HTML version, they must put in `<input type="text" name="_format" value="text" style="display:none" />` into their existing form.