### PR TITLE
Site-wide confirmations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 development.env
 *.py[cod]
+node_modules
 
 # C extensions
 *.so

--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -58,6 +58,13 @@ def http_form_to_dict(data):
 
     return ret, ordered_keys
 
+
+def remove_www(host):
+    if host.startswith('www.'):
+        return host[4:]
+    return host
+
+
 def sitewide_file_exists (url, email):
     url = urljoin(url, '/' + 'formspree_verify_{0}.txt'.format(email))
     log.debug('Checking sitewide file: %s' % url)

--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -1,4 +1,3 @@
-from formspree import settings, log
 import flask
 import werkzeug.datastructures
 import urlparse
@@ -6,6 +5,9 @@ import requests
 import re
 import hashlib
 import hashids
+from urlparse import urljoin
+
+from formspree import settings, log
 
 HASH = lambda x, y: hashlib.md5(x+y+settings.NONCE_SECRET).hexdigest()
 EXCLUDE_KEYS = ['_gotcha', '_next', '_subject', '_cc']
@@ -26,12 +28,12 @@ def ordered_storage(f):
     return decorator
 
 def referrer_to_path(r):
-    log.debug('Referrer was %s' % str(r))
     if not r:
         return ''
     parsed = urlparse.urlparse(r)
-    return parsed.netloc + parsed.path
-
+    n = parsed.netloc + parsed.path
+    log.debug('Referrer was %s, now %s' % (str(r), n))
+    return n
 
 def http_form_to_dict(data):
     '''
@@ -55,3 +57,9 @@ def http_form_to_dict(data):
         ret[r] = ', '.join(ret[r])
 
     return ret, ordered_keys
+
+def sitewide_file_exists (url, email):
+    url = urljoin(url, '/' + 'formspree_verify_{0}.txt'.format(email))
+    log.debug('Checking sitewide file: %s' % url)
+    res = requests.get(url, timeout=2)
+    return res.ok

--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -16,6 +16,7 @@ class Form(DB.Model):
     hash = DB.Column(DB.String(32), unique=True)
     email = DB.Column(DB.String(120))
     host = DB.Column(DB.String(300))
+    sitewide = DB.Column(DB.Boolean)
     confirm_sent = DB.Column(DB.Boolean)
     confirmed = DB.Column(DB.Boolean)
     counter = DB.Column(DB.Integer)

--- a/formspree/routes.py
+++ b/formspree/routes.py
@@ -27,6 +27,7 @@ def configure_routes(app):
     app.add_url_rule('/dashboard', 'dashboard', view_func=forms.views.forms, methods=['GET'])
     app.add_url_rule('/forms', 'forms', view_func=forms.views.forms, methods=['GET'])
     app.add_url_rule('/forms', 'create-form', view_func=forms.views.create_form, methods=['POST'])
+    app.add_url_rule('/forms/sitewide-check', view_func=forms.views.sitewide_check, methods=['GET'])
     app.add_url_rule('/forms/<hashid>/', 'form-submissions', view_func=forms.views.form_submissions, methods=['GET'])
     app.add_url_rule('/forms/<hashid>.<format>', 'form-submissions', view_func=forms.views.form_submissions, methods=['GET'])
 

--- a/formspree/routes.py
+++ b/formspree/routes.py
@@ -25,7 +25,8 @@ def configure_routes(app):
 
     # Users' forms
     app.add_url_rule('/dashboard', 'dashboard', view_func=forms.views.forms, methods=['GET'])
-    app.add_url_rule('/forms', 'forms', view_func=forms.views.forms, methods=['GET', 'POST'])
+    app.add_url_rule('/forms', 'forms', view_func=forms.views.forms, methods=['GET'])
+    app.add_url_rule('/forms', 'create-form', view_func=forms.views.create_form, methods=['POST'])
     app.add_url_rule('/forms/<hashid>/', 'form-submissions', view_func=forms.views.form_submissions, methods=['GET'])
     app.add_url_rule('/forms/<hashid>.<format>', 'form-submissions', view_func=forms.views.form_submissions, methods=['GET'])
 

--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -2350,11 +2350,11 @@ a.alert-box.success:hover {
   .dashboard .create-form form input {
     margin-top: 0;
     clear: both;
-    width: 70%;
+    width: 100%;
     vertical-align: top; }
   .dashboard .create-form form button {
-    padding: 0.63em;
-    width: 27%; }
+    padding: 0.63em 32px;
+    text-align: center; }
   .dashboard .create-form .modal:not(.js):target > *,
   .dashboard .create-form .modal.target > * {
     top: 20%; }
@@ -2382,8 +2382,7 @@ a.alert-box.success:hover {
     float: right;
     padding: 10px;
     font-size: 1.7em; }
-  .dashboard .modal > * .x h4 {
-    float: left;
+  .dashboard .modal > * h4 {
     margin: 0;
     padding: 0;
     margin-top: 13px; }
@@ -3017,5 +3016,3 @@ body.showOverlay .toggleOverlay {
   right: 30%;
   left: 30%;
   width: 40%; }
-
-/*# sourceMappingURL=main.css.map */

--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -2295,6 +2295,15 @@ a.alert-box.success:hover {
   color: #359173;
   border-color: #359173; }
 
+.highlight {
+  padding: 2px 6px;
+  font-weight: bold;
+  font-size: 20px;
+  color: white;
+  background-color: #35918D;
+  border-radius: 3px;
+  margin: 3px; }
+
 .login .row {
   padding: 2.2em 0; }
 .login input, .login button {
@@ -2347,7 +2356,7 @@ a.alert-box.success:hover {
   margin: 3em 0; }
   .dashboard .create-form form {
     clear: both; }
-  .dashboard .create-form form input {
+  .dashboard .create-form form input:not([type="checkbox"]):not([type="radio"]) {
     margin-top: 0;
     clear: both;
     width: 100%;
@@ -2355,6 +2364,8 @@ a.alert-box.success:hover {
   .dashboard .create-form form button {
     padding: 0.63em 32px;
     text-align: center; }
+  .dashboard .create-form .verify-info {
+    font-size: 13px; }
   .dashboard .create-form .modal:not(.js):target > *,
   .dashboard .create-form .modal.target > * {
     top: 20%; }
@@ -2922,6 +2933,9 @@ button, a.button {
     button:hover.emphasis, a.button:hover.emphasis {
       color: white;
       background-color: #2A735B; }
+  button[disabled], button[disabled]:hover, a.button[disabled], a.button[disabled]:hover {
+    color: #b0e2d2;
+    border-color: #b0e2d2; }
 
 .animate {
   -moz-animation-iteration-count: once;

--- a/formspree/static/js/bundle.js
+++ b/formspree/static/js/bundle.js
@@ -1,82 +1,1638 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-const $ = window.$
-const StripeCheckout = window.StripeCheckout
-const toastr = window.toastr
+'use strict';
+
+var url = require('url');
+var isValidEmail = require('is-valid-email');
+
+var $ = window.$;
+var StripeCheckout = window.StripeCheckout;
+var toastr = window.toastr;
+
+toastr.options = { positionClass: 'toast-top-center' };
 
 /* top navbar */
-var nav = $('body > nav')
-nav.addClass('js')
-nav.find('.menu').slicknav()
-nav.find('h4').clone().prependTo('.slicknav_menu')
+var nav = $('body > nav');
+nav.addClass('js');
+nav.find('.menu').slicknav();
+nav.find('h4').clone().prependTo('.slicknav_menu');
 
 /* adding a shadow at the bottom of the menu bar only when not at the top */
-var w = $(window)
+var w = $(window);
 w.scroll(function () {
-  var scrollPos = w.scrollTop()
+  var scrollPos = w.scrollTop();
   if (scrollPos && !nav.hasClass('scrolled')) {
-    nav.addClass('scrolled')
+    nav.addClass('scrolled');
   } else if (!scrollPos) {
-    nav.removeClass('scrolled')
+    nav.removeClass('scrolled');
   }
-})
+});
 
 /* background-color should inherit, but CSS's "inherit" breaks z-index */
-var bgcolor = $(document.body).css('background-color')
+var bgcolor = $(document.body).css('background-color');
 if (bgcolor.split(',').length === 4 || bgcolor === 'transparent') {
-  bgcolor = 'white'
+  bgcolor = 'white';
 }
-nav.css('background-color', bgcolor)
+nav.css('background-color', bgcolor);
 
 /* modal */
 $('.modal').each(function () {
-  var modal = $(this)
-  modal.addClass('js')
-  var id = modal.attr('id')
+  var modal = $(this);
+  modal.addClass('js');
+  var id = modal.attr('id');
   $('[href="#' + id + '"]').click(function (e) {
-    e.preventDefault()
-    modal.toggleClass('target')
-  })
+    e.preventDefault();
+    modal.toggleClass('target');
+  });
   modal.click(function (e) {
     if (e.target === modal[0]) {
-      modal.toggleClass('target')
-      e.preventDefault()
+      modal.toggleClass('target');
+      e.preventDefault();
     }
-  })
+  });
   modal.find('.x a').click(function (e) {
-    e.preventDefault()
-    modal.toggleClass('target')
-  })
-})
+    e.preventDefault();
+    modal.toggleClass('target');
+  });
+});
+
+/* create-form validation for site-wide forms */
+function sitewide() {
+  var createform = $('#create-form');
+  var emailInput = createform.find('input[name="email"]');
+  var urlInput = createform.find('input[name="url"]');
+  var checkbox = createform.find('input[name="sitewide"]');
+  var verifyButton = createform.find('.verify-button');
+  var createButton = createform.find('.create-button');
+  var info = createform.find('.verify-info');
+
+  checkbox.on('change', run);
+  emailInput.on('input', run);
+  urlInput.on('input', run);
+
+  function run() {
+    if (checkbox.is(':checked')) {
+      var email = emailInput.val().trim();
+      var urlp = url.parse(urlInput.val().trim());
+
+      if (isValidEmail(email) && urlp.host) {
+        var sitewideFile = 'formspree_verify_' + email + '.txt';
+        verifyButton.css('visibility', 'visible');
+        info.html('Please ensure <span class="code">' + url.resolve(urlInput.val(), '/' + sitewideFile) + '</span> exists');
+      } else {
+        // wrong input
+        if (!urlp.host) {
+          // invalid url
+          info.text('Please input a valid URL.');
+        } else {
+          // invalid email
+          info.text('Please input a valid email address.');
+        }
+      }
+
+      createButton.find('button').prop('disabled', true);
+      info.css('visibility', 'visible');
+    } else {
+      // toggle sitewide off
+      info.css('visibility', 'hidden');
+      verifyButton.css('visibility', 'hidden');
+      createButton.css('visibility', 'visible');
+    }
+  }
+
+  verifyButton.find('button').on('click', function () {
+    $.ajax({
+      url: '/forms/sitewide-check?' + createform.find('form').serialize(),
+      success: function success() {
+        toastr.success('The file exists! you can create your site-wide form now.');
+        createButton.find('button').prop('disabled', false);
+        verifyButton.css('visibility', 'hidden');
+        info.css('visibility', 'hidden');
+      },
+      error: function error() {
+        toastr.warning("The verification file wasn't found.");
+        verifyButton.find('button').prop('disabled', true);
+        setTimeout(function () {
+          verifyButton.find('button').prop('disabled', false);
+        }, 5000);
+      }
+    });
+    return false;
+  });
+}
+sitewide();
 
 /* turning flask flash messages into js popup notifications */
-toastr.options = { positionClass: 'toast-top-center' }
 window.popupMessages.forEach(function (m, i) {
-  var category = m[0] || 'info'
-  var text = m[1]
-  setTimeout(function () { toastr[category](text) }, (1 + i) * 1500)
-})
+  var category = m[0] || 'info';
+  var text = m[1];
+  setTimeout(function () {
+    toastr[category](text);
+  }, (1 + i) * 1500);
+});
 
 /* stripe checkout */
-var stripebutton = $('#stripe-upgrade')
+var stripebutton = $('#stripe-upgrade');
 if (stripebutton.length) {
-  var handler = StripeCheckout.configure(stripebutton.data())
+  var handler = StripeCheckout.configure(stripebutton.data());
   stripebutton.on('click', function (e) {
     handler.open({
-      token: function (token) {
-        stripebutton.closest('form')
-          .append(`<input type="hidden" name="stripeToken" value="${token.id}">`)
-          .append(`<input type="hidden" name="stripeEmail" value="${token.email}">`)
-          .submit()
+      token: function token(_token) {
+        stripebutton.closest('form').append('<input type="hidden" name="stripeToken" value="' + _token.id + '">').append('<input type="hidden" name="stripeEmail" value="' + _token.email + '">').submit();
       }
-    })
-    e.preventDefault()
-  })
+    });
+    e.preventDefault();
+  });
 }
 
 /* quick script for showing the resend confirmation form */
 $('a.resend').on('click', function () {
-  $(this).hide()
-  $('form.resend').show()
-})
+  $(this).hide();
+  $('form.resend').show();
+});
+
+},{"is-valid-email":2,"url":7}],2:[function(require,module,exports){
+(function(){
+
+  function isValidEmail(v) {
+    if (!v) return false;
+    var re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    return re.test(v);
+  }
+
+  if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+    module.exports = isValidEmail;
+  } else {
+    window.isValidEmail = isValidEmail;
+  }
+
+})();
+
+},{}],3:[function(require,module,exports){
+(function (global){
+/*! https://mths.be/punycode v1.4.0 by @mathias */
+;(function(root) {
+
+	/** Detect free variables */
+	var freeExports = typeof exports == 'object' && exports &&
+		!exports.nodeType && exports;
+	var freeModule = typeof module == 'object' && module &&
+		!module.nodeType && module;
+	var freeGlobal = typeof global == 'object' && global;
+	if (
+		freeGlobal.global === freeGlobal ||
+		freeGlobal.window === freeGlobal ||
+		freeGlobal.self === freeGlobal
+	) {
+		root = freeGlobal;
+	}
+
+	/**
+	 * The `punycode` object.
+	 * @name punycode
+	 * @type Object
+	 */
+	var punycode,
+
+	/** Highest positive signed 32-bit float value */
+	maxInt = 2147483647, // aka. 0x7FFFFFFF or 2^31-1
+
+	/** Bootstring parameters */
+	base = 36,
+	tMin = 1,
+	tMax = 26,
+	skew = 38,
+	damp = 700,
+	initialBias = 72,
+	initialN = 128, // 0x80
+	delimiter = '-', // '\x2D'
+
+	/** Regular expressions */
+	regexPunycode = /^xn--/,
+	regexNonASCII = /[^\x20-\x7E]/, // unprintable ASCII chars + non-ASCII chars
+	regexSeparators = /[\x2E\u3002\uFF0E\uFF61]/g, // RFC 3490 separators
+
+	/** Error messages */
+	errors = {
+		'overflow': 'Overflow: input needs wider integers to process',
+		'not-basic': 'Illegal input >= 0x80 (not a basic code point)',
+		'invalid-input': 'Invalid input'
+	},
+
+	/** Convenience shortcuts */
+	baseMinusTMin = base - tMin,
+	floor = Math.floor,
+	stringFromCharCode = String.fromCharCode,
+
+	/** Temporary variable */
+	key;
+
+	/*--------------------------------------------------------------------------*/
+
+	/**
+	 * A generic error utility function.
+	 * @private
+	 * @param {String} type The error type.
+	 * @returns {Error} Throws a `RangeError` with the applicable error message.
+	 */
+	function error(type) {
+		throw new RangeError(errors[type]);
+	}
+
+	/**
+	 * A generic `Array#map` utility function.
+	 * @private
+	 * @param {Array} array The array to iterate over.
+	 * @param {Function} callback The function that gets called for every array
+	 * item.
+	 * @returns {Array} A new array of values returned by the callback function.
+	 */
+	function map(array, fn) {
+		var length = array.length;
+		var result = [];
+		while (length--) {
+			result[length] = fn(array[length]);
+		}
+		return result;
+	}
+
+	/**
+	 * A simple `Array#map`-like wrapper to work with domain name strings or email
+	 * addresses.
+	 * @private
+	 * @param {String} domain The domain name or email address.
+	 * @param {Function} callback The function that gets called for every
+	 * character.
+	 * @returns {Array} A new string of characters returned by the callback
+	 * function.
+	 */
+	function mapDomain(string, fn) {
+		var parts = string.split('@');
+		var result = '';
+		if (parts.length > 1) {
+			// In email addresses, only the domain name should be punycoded. Leave
+			// the local part (i.e. everything up to `@`) intact.
+			result = parts[0] + '@';
+			string = parts[1];
+		}
+		// Avoid `split(regex)` for IE8 compatibility. See #17.
+		string = string.replace(regexSeparators, '\x2E');
+		var labels = string.split('.');
+		var encoded = map(labels, fn).join('.');
+		return result + encoded;
+	}
+
+	/**
+	 * Creates an array containing the numeric code points of each Unicode
+	 * character in the string. While JavaScript uses UCS-2 internally,
+	 * this function will convert a pair of surrogate halves (each of which
+	 * UCS-2 exposes as separate characters) into a single code point,
+	 * matching UTF-16.
+	 * @see `punycode.ucs2.encode`
+	 * @see <https://mathiasbynens.be/notes/javascript-encoding>
+	 * @memberOf punycode.ucs2
+	 * @name decode
+	 * @param {String} string The Unicode input string (UCS-2).
+	 * @returns {Array} The new array of code points.
+	 */
+	function ucs2decode(string) {
+		var output = [],
+		    counter = 0,
+		    length = string.length,
+		    value,
+		    extra;
+		while (counter < length) {
+			value = string.charCodeAt(counter++);
+			if (value >= 0xD800 && value <= 0xDBFF && counter < length) {
+				// high surrogate, and there is a next character
+				extra = string.charCodeAt(counter++);
+				if ((extra & 0xFC00) == 0xDC00) { // low surrogate
+					output.push(((value & 0x3FF) << 10) + (extra & 0x3FF) + 0x10000);
+				} else {
+					// unmatched surrogate; only append this code unit, in case the next
+					// code unit is the high surrogate of a surrogate pair
+					output.push(value);
+					counter--;
+				}
+			} else {
+				output.push(value);
+			}
+		}
+		return output;
+	}
+
+	/**
+	 * Creates a string based on an array of numeric code points.
+	 * @see `punycode.ucs2.decode`
+	 * @memberOf punycode.ucs2
+	 * @name encode
+	 * @param {Array} codePoints The array of numeric code points.
+	 * @returns {String} The new Unicode string (UCS-2).
+	 */
+	function ucs2encode(array) {
+		return map(array, function(value) {
+			var output = '';
+			if (value > 0xFFFF) {
+				value -= 0x10000;
+				output += stringFromCharCode(value >>> 10 & 0x3FF | 0xD800);
+				value = 0xDC00 | value & 0x3FF;
+			}
+			output += stringFromCharCode(value);
+			return output;
+		}).join('');
+	}
+
+	/**
+	 * Converts a basic code point into a digit/integer.
+	 * @see `digitToBasic()`
+	 * @private
+	 * @param {Number} codePoint The basic numeric code point value.
+	 * @returns {Number} The numeric value of a basic code point (for use in
+	 * representing integers) in the range `0` to `base - 1`, or `base` if
+	 * the code point does not represent a value.
+	 */
+	function basicToDigit(codePoint) {
+		if (codePoint - 48 < 10) {
+			return codePoint - 22;
+		}
+		if (codePoint - 65 < 26) {
+			return codePoint - 65;
+		}
+		if (codePoint - 97 < 26) {
+			return codePoint - 97;
+		}
+		return base;
+	}
+
+	/**
+	 * Converts a digit/integer into a basic code point.
+	 * @see `basicToDigit()`
+	 * @private
+	 * @param {Number} digit The numeric value of a basic code point.
+	 * @returns {Number} The basic code point whose value (when used for
+	 * representing integers) is `digit`, which needs to be in the range
+	 * `0` to `base - 1`. If `flag` is non-zero, the uppercase form is
+	 * used; else, the lowercase form is used. The behavior is undefined
+	 * if `flag` is non-zero and `digit` has no uppercase form.
+	 */
+	function digitToBasic(digit, flag) {
+		//  0..25 map to ASCII a..z or A..Z
+		// 26..35 map to ASCII 0..9
+		return digit + 22 + 75 * (digit < 26) - ((flag != 0) << 5);
+	}
+
+	/**
+	 * Bias adaptation function as per section 3.4 of RFC 3492.
+	 * https://tools.ietf.org/html/rfc3492#section-3.4
+	 * @private
+	 */
+	function adapt(delta, numPoints, firstTime) {
+		var k = 0;
+		delta = firstTime ? floor(delta / damp) : delta >> 1;
+		delta += floor(delta / numPoints);
+		for (/* no initialization */; delta > baseMinusTMin * tMax >> 1; k += base) {
+			delta = floor(delta / baseMinusTMin);
+		}
+		return floor(k + (baseMinusTMin + 1) * delta / (delta + skew));
+	}
+
+	/**
+	 * Converts a Punycode string of ASCII-only symbols to a string of Unicode
+	 * symbols.
+	 * @memberOf punycode
+	 * @param {String} input The Punycode string of ASCII-only symbols.
+	 * @returns {String} The resulting string of Unicode symbols.
+	 */
+	function decode(input) {
+		// Don't use UCS-2
+		var output = [],
+		    inputLength = input.length,
+		    out,
+		    i = 0,
+		    n = initialN,
+		    bias = initialBias,
+		    basic,
+		    j,
+		    index,
+		    oldi,
+		    w,
+		    k,
+		    digit,
+		    t,
+		    /** Cached calculation results */
+		    baseMinusT;
+
+		// Handle the basic code points: let `basic` be the number of input code
+		// points before the last delimiter, or `0` if there is none, then copy
+		// the first basic code points to the output.
+
+		basic = input.lastIndexOf(delimiter);
+		if (basic < 0) {
+			basic = 0;
+		}
+
+		for (j = 0; j < basic; ++j) {
+			// if it's not a basic code point
+			if (input.charCodeAt(j) >= 0x80) {
+				error('not-basic');
+			}
+			output.push(input.charCodeAt(j));
+		}
+
+		// Main decoding loop: start just after the last delimiter if any basic code
+		// points were copied; start at the beginning otherwise.
+
+		for (index = basic > 0 ? basic + 1 : 0; index < inputLength; /* no final expression */) {
+
+			// `index` is the index of the next character to be consumed.
+			// Decode a generalized variable-length integer into `delta`,
+			// which gets added to `i`. The overflow checking is easier
+			// if we increase `i` as we go, then subtract off its starting
+			// value at the end to obtain `delta`.
+			for (oldi = i, w = 1, k = base; /* no condition */; k += base) {
+
+				if (index >= inputLength) {
+					error('invalid-input');
+				}
+
+				digit = basicToDigit(input.charCodeAt(index++));
+
+				if (digit >= base || digit > floor((maxInt - i) / w)) {
+					error('overflow');
+				}
+
+				i += digit * w;
+				t = k <= bias ? tMin : (k >= bias + tMax ? tMax : k - bias);
+
+				if (digit < t) {
+					break;
+				}
+
+				baseMinusT = base - t;
+				if (w > floor(maxInt / baseMinusT)) {
+					error('overflow');
+				}
+
+				w *= baseMinusT;
+
+			}
+
+			out = output.length + 1;
+			bias = adapt(i - oldi, out, oldi == 0);
+
+			// `i` was supposed to wrap around from `out` to `0`,
+			// incrementing `n` each time, so we'll fix that now:
+			if (floor(i / out) > maxInt - n) {
+				error('overflow');
+			}
+
+			n += floor(i / out);
+			i %= out;
+
+			// Insert `n` at position `i` of the output
+			output.splice(i++, 0, n);
+
+		}
+
+		return ucs2encode(output);
+	}
+
+	/**
+	 * Converts a string of Unicode symbols (e.g. a domain name label) to a
+	 * Punycode string of ASCII-only symbols.
+	 * @memberOf punycode
+	 * @param {String} input The string of Unicode symbols.
+	 * @returns {String} The resulting Punycode string of ASCII-only symbols.
+	 */
+	function encode(input) {
+		var n,
+		    delta,
+		    handledCPCount,
+		    basicLength,
+		    bias,
+		    j,
+		    m,
+		    q,
+		    k,
+		    t,
+		    currentValue,
+		    output = [],
+		    /** `inputLength` will hold the number of code points in `input`. */
+		    inputLength,
+		    /** Cached calculation results */
+		    handledCPCountPlusOne,
+		    baseMinusT,
+		    qMinusT;
+
+		// Convert the input in UCS-2 to Unicode
+		input = ucs2decode(input);
+
+		// Cache the length
+		inputLength = input.length;
+
+		// Initialize the state
+		n = initialN;
+		delta = 0;
+		bias = initialBias;
+
+		// Handle the basic code points
+		for (j = 0; j < inputLength; ++j) {
+			currentValue = input[j];
+			if (currentValue < 0x80) {
+				output.push(stringFromCharCode(currentValue));
+			}
+		}
+
+		handledCPCount = basicLength = output.length;
+
+		// `handledCPCount` is the number of code points that have been handled;
+		// `basicLength` is the number of basic code points.
+
+		// Finish the basic string - if it is not empty - with a delimiter
+		if (basicLength) {
+			output.push(delimiter);
+		}
+
+		// Main encoding loop:
+		while (handledCPCount < inputLength) {
+
+			// All non-basic code points < n have been handled already. Find the next
+			// larger one:
+			for (m = maxInt, j = 0; j < inputLength; ++j) {
+				currentValue = input[j];
+				if (currentValue >= n && currentValue < m) {
+					m = currentValue;
+				}
+			}
+
+			// Increase `delta` enough to advance the decoder's <n,i> state to <m,0>,
+			// but guard against overflow
+			handledCPCountPlusOne = handledCPCount + 1;
+			if (m - n > floor((maxInt - delta) / handledCPCountPlusOne)) {
+				error('overflow');
+			}
+
+			delta += (m - n) * handledCPCountPlusOne;
+			n = m;
+
+			for (j = 0; j < inputLength; ++j) {
+				currentValue = input[j];
+
+				if (currentValue < n && ++delta > maxInt) {
+					error('overflow');
+				}
+
+				if (currentValue == n) {
+					// Represent delta as a generalized variable-length integer
+					for (q = delta, k = base; /* no condition */; k += base) {
+						t = k <= bias ? tMin : (k >= bias + tMax ? tMax : k - bias);
+						if (q < t) {
+							break;
+						}
+						qMinusT = q - t;
+						baseMinusT = base - t;
+						output.push(
+							stringFromCharCode(digitToBasic(t + qMinusT % baseMinusT, 0))
+						);
+						q = floor(qMinusT / baseMinusT);
+					}
+
+					output.push(stringFromCharCode(digitToBasic(q, 0)));
+					bias = adapt(delta, handledCPCountPlusOne, handledCPCount == basicLength);
+					delta = 0;
+					++handledCPCount;
+				}
+			}
+
+			++delta;
+			++n;
+
+		}
+		return output.join('');
+	}
+
+	/**
+	 * Converts a Punycode string representing a domain name or an email address
+	 * to Unicode. Only the Punycoded parts of the input will be converted, i.e.
+	 * it doesn't matter if you call it on a string that has already been
+	 * converted to Unicode.
+	 * @memberOf punycode
+	 * @param {String} input The Punycoded domain name or email address to
+	 * convert to Unicode.
+	 * @returns {String} The Unicode representation of the given Punycode
+	 * string.
+	 */
+	function toUnicode(input) {
+		return mapDomain(input, function(string) {
+			return regexPunycode.test(string)
+				? decode(string.slice(4).toLowerCase())
+				: string;
+		});
+	}
+
+	/**
+	 * Converts a Unicode string representing a domain name or an email address to
+	 * Punycode. Only the non-ASCII parts of the domain name will be converted,
+	 * i.e. it doesn't matter if you call it with a domain that's already in
+	 * ASCII.
+	 * @memberOf punycode
+	 * @param {String} input The domain name or email address to convert, as a
+	 * Unicode string.
+	 * @returns {String} The Punycode representation of the given domain name or
+	 * email address.
+	 */
+	function toASCII(input) {
+		return mapDomain(input, function(string) {
+			return regexNonASCII.test(string)
+				? 'xn--' + encode(string)
+				: string;
+		});
+	}
+
+	/*--------------------------------------------------------------------------*/
+
+	/** Define the public API */
+	punycode = {
+		/**
+		 * A string representing the current Punycode.js version number.
+		 * @memberOf punycode
+		 * @type String
+		 */
+		'version': '1.3.2',
+		/**
+		 * An object of methods to convert from JavaScript's internal character
+		 * representation (UCS-2) to Unicode code points, and back.
+		 * @see <https://mathiasbynens.be/notes/javascript-encoding>
+		 * @memberOf punycode
+		 * @type Object
+		 */
+		'ucs2': {
+			'decode': ucs2decode,
+			'encode': ucs2encode
+		},
+		'decode': decode,
+		'encode': encode,
+		'toASCII': toASCII,
+		'toUnicode': toUnicode
+	};
+
+	/** Expose `punycode` */
+	// Some AMD build optimizers, like r.js, check for specific condition patterns
+	// like the following:
+	if (
+		typeof define == 'function' &&
+		typeof define.amd == 'object' &&
+		define.amd
+	) {
+		define('punycode', function() {
+			return punycode;
+		});
+	} else if (freeExports && freeModule) {
+		if (module.exports == freeExports) {
+			// in Node.js, io.js, or RingoJS v0.8.0+
+			freeModule.exports = punycode;
+		} else {
+			// in Narwhal or RingoJS v0.7.0-
+			for (key in punycode) {
+				punycode.hasOwnProperty(key) && (freeExports[key] = punycode[key]);
+			}
+		}
+	} else {
+		// in Rhino or a web browser
+		root.punycode = punycode;
+	}
+
+}(this));
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{}],4:[function(require,module,exports){
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+// If obj.hasOwnProperty has been overridden, then calling
+// obj.hasOwnProperty(prop) will break.
+// See: https://github.com/joyent/node/issues/1707
+function hasOwnProperty(obj, prop) {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+}
+
+module.exports = function(qs, sep, eq, options) {
+  sep = sep || '&';
+  eq = eq || '=';
+  var obj = {};
+
+  if (typeof qs !== 'string' || qs.length === 0) {
+    return obj;
+  }
+
+  var regexp = /\+/g;
+  qs = qs.split(sep);
+
+  var maxKeys = 1000;
+  if (options && typeof options.maxKeys === 'number') {
+    maxKeys = options.maxKeys;
+  }
+
+  var len = qs.length;
+  // maxKeys <= 0 means that we should not limit keys count
+  if (maxKeys > 0 && len > maxKeys) {
+    len = maxKeys;
+  }
+
+  for (var i = 0; i < len; ++i) {
+    var x = qs[i].replace(regexp, '%20'),
+        idx = x.indexOf(eq),
+        kstr, vstr, k, v;
+
+    if (idx >= 0) {
+      kstr = x.substr(0, idx);
+      vstr = x.substr(idx + 1);
+    } else {
+      kstr = x;
+      vstr = '';
+    }
+
+    k = decodeURIComponent(kstr);
+    v = decodeURIComponent(vstr);
+
+    if (!hasOwnProperty(obj, k)) {
+      obj[k] = v;
+    } else if (isArray(obj[k])) {
+      obj[k].push(v);
+    } else {
+      obj[k] = [obj[k], v];
+    }
+  }
+
+  return obj;
+};
+
+var isArray = Array.isArray || function (xs) {
+  return Object.prototype.toString.call(xs) === '[object Array]';
+};
+
+},{}],5:[function(require,module,exports){
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+var stringifyPrimitive = function(v) {
+  switch (typeof v) {
+    case 'string':
+      return v;
+
+    case 'boolean':
+      return v ? 'true' : 'false';
+
+    case 'number':
+      return isFinite(v) ? v : '';
+
+    default:
+      return '';
+  }
+};
+
+module.exports = function(obj, sep, eq, name) {
+  sep = sep || '&';
+  eq = eq || '=';
+  if (obj === null) {
+    obj = undefined;
+  }
+
+  if (typeof obj === 'object') {
+    return map(objectKeys(obj), function(k) {
+      var ks = encodeURIComponent(stringifyPrimitive(k)) + eq;
+      if (isArray(obj[k])) {
+        return map(obj[k], function(v) {
+          return ks + encodeURIComponent(stringifyPrimitive(v));
+        }).join(sep);
+      } else {
+        return ks + encodeURIComponent(stringifyPrimitive(obj[k]));
+      }
+    }).join(sep);
+
+  }
+
+  if (!name) return '';
+  return encodeURIComponent(stringifyPrimitive(name)) + eq +
+         encodeURIComponent(stringifyPrimitive(obj));
+};
+
+var isArray = Array.isArray || function (xs) {
+  return Object.prototype.toString.call(xs) === '[object Array]';
+};
+
+function map (xs, f) {
+  if (xs.map) return xs.map(f);
+  var res = [];
+  for (var i = 0; i < xs.length; i++) {
+    res.push(f(xs[i], i));
+  }
+  return res;
+}
+
+var objectKeys = Object.keys || function (obj) {
+  var res = [];
+  for (var key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) res.push(key);
+  }
+  return res;
+};
+
+},{}],6:[function(require,module,exports){
+'use strict';
+
+exports.decode = exports.parse = require('./decode');
+exports.encode = exports.stringify = require('./encode');
+
+},{"./decode":4,"./encode":5}],7:[function(require,module,exports){
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+var punycode = require('punycode');
+var util = require('./util');
+
+exports.parse = urlParse;
+exports.resolve = urlResolve;
+exports.resolveObject = urlResolveObject;
+exports.format = urlFormat;
+
+exports.Url = Url;
+
+function Url() {
+  this.protocol = null;
+  this.slashes = null;
+  this.auth = null;
+  this.host = null;
+  this.port = null;
+  this.hostname = null;
+  this.hash = null;
+  this.search = null;
+  this.query = null;
+  this.pathname = null;
+  this.path = null;
+  this.href = null;
+}
+
+// Reference: RFC 3986, RFC 1808, RFC 2396
+
+// define these here so at least they only have to be
+// compiled once on the first module load.
+var protocolPattern = /^([a-z0-9.+-]+:)/i,
+    portPattern = /:[0-9]*$/,
+
+    // Special case for a simple path URL
+    simplePathPattern = /^(\/\/?(?!\/)[^\?\s]*)(\?[^\s]*)?$/,
+
+    // RFC 2396: characters reserved for delimiting URLs.
+    // We actually just auto-escape these.
+    delims = ['<', '>', '"', '`', ' ', '\r', '\n', '\t'],
+
+    // RFC 2396: characters not allowed for various reasons.
+    unwise = ['{', '}', '|', '\\', '^', '`'].concat(delims),
+
+    // Allowed by RFCs, but cause of XSS attacks.  Always escape these.
+    autoEscape = ['\''].concat(unwise),
+    // Characters that are never ever allowed in a hostname.
+    // Note that any invalid chars are also handled, but these
+    // are the ones that are *expected* to be seen, so we fast-path
+    // them.
+    nonHostChars = ['%', '/', '?', ';', '#'].concat(autoEscape),
+    hostEndingChars = ['/', '?', '#'],
+    hostnameMaxLen = 255,
+    hostnamePartPattern = /^[+a-z0-9A-Z_-]{0,63}$/,
+    hostnamePartStart = /^([+a-z0-9A-Z_-]{0,63})(.*)$/,
+    // protocols that can allow "unsafe" and "unwise" chars.
+    unsafeProtocol = {
+      'javascript': true,
+      'javascript:': true
+    },
+    // protocols that never have a hostname.
+    hostlessProtocol = {
+      'javascript': true,
+      'javascript:': true
+    },
+    // protocols that always contain a // bit.
+    slashedProtocol = {
+      'http': true,
+      'https': true,
+      'ftp': true,
+      'gopher': true,
+      'file': true,
+      'http:': true,
+      'https:': true,
+      'ftp:': true,
+      'gopher:': true,
+      'file:': true
+    },
+    querystring = require('querystring');
+
+function urlParse(url, parseQueryString, slashesDenoteHost) {
+  if (url && util.isObject(url) && url instanceof Url) return url;
+
+  var u = new Url;
+  u.parse(url, parseQueryString, slashesDenoteHost);
+  return u;
+}
+
+Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
+  if (!util.isString(url)) {
+    throw new TypeError("Parameter 'url' must be a string, not " + typeof url);
+  }
+
+  // Copy chrome, IE, opera backslash-handling behavior.
+  // Back slashes before the query string get converted to forward slashes
+  // See: https://code.google.com/p/chromium/issues/detail?id=25916
+  var queryIndex = url.indexOf('?'),
+      splitter =
+          (queryIndex !== -1 && queryIndex < url.indexOf('#')) ? '?' : '#',
+      uSplit = url.split(splitter),
+      slashRegex = /\\/g;
+  uSplit[0] = uSplit[0].replace(slashRegex, '/');
+  url = uSplit.join(splitter);
+
+  var rest = url;
+
+  // trim before proceeding.
+  // This is to support parse stuff like "  http://foo.com  \n"
+  rest = rest.trim();
+
+  if (!slashesDenoteHost && url.split('#').length === 1) {
+    // Try fast path regexp
+    var simplePath = simplePathPattern.exec(rest);
+    if (simplePath) {
+      this.path = rest;
+      this.href = rest;
+      this.pathname = simplePath[1];
+      if (simplePath[2]) {
+        this.search = simplePath[2];
+        if (parseQueryString) {
+          this.query = querystring.parse(this.search.substr(1));
+        } else {
+          this.query = this.search.substr(1);
+        }
+      } else if (parseQueryString) {
+        this.search = '';
+        this.query = {};
+      }
+      return this;
+    }
+  }
+
+  var proto = protocolPattern.exec(rest);
+  if (proto) {
+    proto = proto[0];
+    var lowerProto = proto.toLowerCase();
+    this.protocol = lowerProto;
+    rest = rest.substr(proto.length);
+  }
+
+  // figure out if it's got a host
+  // user@server is *always* interpreted as a hostname, and url
+  // resolution will treat //foo/bar as host=foo,path=bar because that's
+  // how the browser resolves relative URLs.
+  if (slashesDenoteHost || proto || rest.match(/^\/\/[^@\/]+@[^@\/]+/)) {
+    var slashes = rest.substr(0, 2) === '//';
+    if (slashes && !(proto && hostlessProtocol[proto])) {
+      rest = rest.substr(2);
+      this.slashes = true;
+    }
+  }
+
+  if (!hostlessProtocol[proto] &&
+      (slashes || (proto && !slashedProtocol[proto]))) {
+
+    // there's a hostname.
+    // the first instance of /, ?, ;, or # ends the host.
+    //
+    // If there is an @ in the hostname, then non-host chars *are* allowed
+    // to the left of the last @ sign, unless some host-ending character
+    // comes *before* the @-sign.
+    // URLs are obnoxious.
+    //
+    // ex:
+    // http://a@b@c/ => user:a@b host:c
+    // http://a@b?@c => user:a host:c path:/?@c
+
+    // v0.12 TODO(isaacs): This is not quite how Chrome does things.
+    // Review our test case against browsers more comprehensively.
+
+    // find the first instance of any hostEndingChars
+    var hostEnd = -1;
+    for (var i = 0; i < hostEndingChars.length; i++) {
+      var hec = rest.indexOf(hostEndingChars[i]);
+      if (hec !== -1 && (hostEnd === -1 || hec < hostEnd))
+        hostEnd = hec;
+    }
+
+    // at this point, either we have an explicit point where the
+    // auth portion cannot go past, or the last @ char is the decider.
+    var auth, atSign;
+    if (hostEnd === -1) {
+      // atSign can be anywhere.
+      atSign = rest.lastIndexOf('@');
+    } else {
+      // atSign must be in auth portion.
+      // http://a@b/c@d => host:b auth:a path:/c@d
+      atSign = rest.lastIndexOf('@', hostEnd);
+    }
+
+    // Now we have a portion which is definitely the auth.
+    // Pull that off.
+    if (atSign !== -1) {
+      auth = rest.slice(0, atSign);
+      rest = rest.slice(atSign + 1);
+      this.auth = decodeURIComponent(auth);
+    }
+
+    // the host is the remaining to the left of the first non-host char
+    hostEnd = -1;
+    for (var i = 0; i < nonHostChars.length; i++) {
+      var hec = rest.indexOf(nonHostChars[i]);
+      if (hec !== -1 && (hostEnd === -1 || hec < hostEnd))
+        hostEnd = hec;
+    }
+    // if we still have not hit it, then the entire thing is a host.
+    if (hostEnd === -1)
+      hostEnd = rest.length;
+
+    this.host = rest.slice(0, hostEnd);
+    rest = rest.slice(hostEnd);
+
+    // pull out port.
+    this.parseHost();
+
+    // we've indicated that there is a hostname,
+    // so even if it's empty, it has to be present.
+    this.hostname = this.hostname || '';
+
+    // if hostname begins with [ and ends with ]
+    // assume that it's an IPv6 address.
+    var ipv6Hostname = this.hostname[0] === '[' &&
+        this.hostname[this.hostname.length - 1] === ']';
+
+    // validate a little.
+    if (!ipv6Hostname) {
+      var hostparts = this.hostname.split(/\./);
+      for (var i = 0, l = hostparts.length; i < l; i++) {
+        var part = hostparts[i];
+        if (!part) continue;
+        if (!part.match(hostnamePartPattern)) {
+          var newpart = '';
+          for (var j = 0, k = part.length; j < k; j++) {
+            if (part.charCodeAt(j) > 127) {
+              // we replace non-ASCII char with a temporary placeholder
+              // we need this to make sure size of hostname is not
+              // broken by replacing non-ASCII by nothing
+              newpart += 'x';
+            } else {
+              newpart += part[j];
+            }
+          }
+          // we test again with ASCII char only
+          if (!newpart.match(hostnamePartPattern)) {
+            var validParts = hostparts.slice(0, i);
+            var notHost = hostparts.slice(i + 1);
+            var bit = part.match(hostnamePartStart);
+            if (bit) {
+              validParts.push(bit[1]);
+              notHost.unshift(bit[2]);
+            }
+            if (notHost.length) {
+              rest = '/' + notHost.join('.') + rest;
+            }
+            this.hostname = validParts.join('.');
+            break;
+          }
+        }
+      }
+    }
+
+    if (this.hostname.length > hostnameMaxLen) {
+      this.hostname = '';
+    } else {
+      // hostnames are always lower case.
+      this.hostname = this.hostname.toLowerCase();
+    }
+
+    if (!ipv6Hostname) {
+      // IDNA Support: Returns a punycoded representation of "domain".
+      // It only converts parts of the domain name that
+      // have non-ASCII characters, i.e. it doesn't matter if
+      // you call it with a domain that already is ASCII-only.
+      this.hostname = punycode.toASCII(this.hostname);
+    }
+
+    var p = this.port ? ':' + this.port : '';
+    var h = this.hostname || '';
+    this.host = h + p;
+    this.href += this.host;
+
+    // strip [ and ] from the hostname
+    // the host field still retains them, though
+    if (ipv6Hostname) {
+      this.hostname = this.hostname.substr(1, this.hostname.length - 2);
+      if (rest[0] !== '/') {
+        rest = '/' + rest;
+      }
+    }
+  }
+
+  // now rest is set to the post-host stuff.
+  // chop off any delim chars.
+  if (!unsafeProtocol[lowerProto]) {
+
+    // First, make 100% sure that any "autoEscape" chars get
+    // escaped, even if encodeURIComponent doesn't think they
+    // need to be.
+    for (var i = 0, l = autoEscape.length; i < l; i++) {
+      var ae = autoEscape[i];
+      if (rest.indexOf(ae) === -1)
+        continue;
+      var esc = encodeURIComponent(ae);
+      if (esc === ae) {
+        esc = escape(ae);
+      }
+      rest = rest.split(ae).join(esc);
+    }
+  }
+
+
+  // chop off from the tail first.
+  var hash = rest.indexOf('#');
+  if (hash !== -1) {
+    // got a fragment string.
+    this.hash = rest.substr(hash);
+    rest = rest.slice(0, hash);
+  }
+  var qm = rest.indexOf('?');
+  if (qm !== -1) {
+    this.search = rest.substr(qm);
+    this.query = rest.substr(qm + 1);
+    if (parseQueryString) {
+      this.query = querystring.parse(this.query);
+    }
+    rest = rest.slice(0, qm);
+  } else if (parseQueryString) {
+    // no query string, but parseQueryString still requested
+    this.search = '';
+    this.query = {};
+  }
+  if (rest) this.pathname = rest;
+  if (slashedProtocol[lowerProto] &&
+      this.hostname && !this.pathname) {
+    this.pathname = '/';
+  }
+
+  //to support http.request
+  if (this.pathname || this.search) {
+    var p = this.pathname || '';
+    var s = this.search || '';
+    this.path = p + s;
+  }
+
+  // finally, reconstruct the href based on what has been validated.
+  this.href = this.format();
+  return this;
+};
+
+// format a parsed object into a url string
+function urlFormat(obj) {
+  // ensure it's an object, and not a string url.
+  // If it's an obj, this is a no-op.
+  // this way, you can call url_format() on strings
+  // to clean up potentially wonky urls.
+  if (util.isString(obj)) obj = urlParse(obj);
+  if (!(obj instanceof Url)) return Url.prototype.format.call(obj);
+  return obj.format();
+}
+
+Url.prototype.format = function() {
+  var auth = this.auth || '';
+  if (auth) {
+    auth = encodeURIComponent(auth);
+    auth = auth.replace(/%3A/i, ':');
+    auth += '@';
+  }
+
+  var protocol = this.protocol || '',
+      pathname = this.pathname || '',
+      hash = this.hash || '',
+      host = false,
+      query = '';
+
+  if (this.host) {
+    host = auth + this.host;
+  } else if (this.hostname) {
+    host = auth + (this.hostname.indexOf(':') === -1 ?
+        this.hostname :
+        '[' + this.hostname + ']');
+    if (this.port) {
+      host += ':' + this.port;
+    }
+  }
+
+  if (this.query &&
+      util.isObject(this.query) &&
+      Object.keys(this.query).length) {
+    query = querystring.stringify(this.query);
+  }
+
+  var search = this.search || (query && ('?' + query)) || '';
+
+  if (protocol && protocol.substr(-1) !== ':') protocol += ':';
+
+  // only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
+  // unless they had them to begin with.
+  if (this.slashes ||
+      (!protocol || slashedProtocol[protocol]) && host !== false) {
+    host = '//' + (host || '');
+    if (pathname && pathname.charAt(0) !== '/') pathname = '/' + pathname;
+  } else if (!host) {
+    host = '';
+  }
+
+  if (hash && hash.charAt(0) !== '#') hash = '#' + hash;
+  if (search && search.charAt(0) !== '?') search = '?' + search;
+
+  pathname = pathname.replace(/[?#]/g, function(match) {
+    return encodeURIComponent(match);
+  });
+  search = search.replace('#', '%23');
+
+  return protocol + host + pathname + search + hash;
+};
+
+function urlResolve(source, relative) {
+  return urlParse(source, false, true).resolve(relative);
+}
+
+Url.prototype.resolve = function(relative) {
+  return this.resolveObject(urlParse(relative, false, true)).format();
+};
+
+function urlResolveObject(source, relative) {
+  if (!source) return relative;
+  return urlParse(source, false, true).resolveObject(relative);
+}
+
+Url.prototype.resolveObject = function(relative) {
+  if (util.isString(relative)) {
+    var rel = new Url();
+    rel.parse(relative, false, true);
+    relative = rel;
+  }
+
+  var result = new Url();
+  var tkeys = Object.keys(this);
+  for (var tk = 0; tk < tkeys.length; tk++) {
+    var tkey = tkeys[tk];
+    result[tkey] = this[tkey];
+  }
+
+  // hash is always overridden, no matter what.
+  // even href="" will remove it.
+  result.hash = relative.hash;
+
+  // if the relative url is empty, then there's nothing left to do here.
+  if (relative.href === '') {
+    result.href = result.format();
+    return result;
+  }
+
+  // hrefs like //foo/bar always cut to the protocol.
+  if (relative.slashes && !relative.protocol) {
+    // take everything except the protocol from relative
+    var rkeys = Object.keys(relative);
+    for (var rk = 0; rk < rkeys.length; rk++) {
+      var rkey = rkeys[rk];
+      if (rkey !== 'protocol')
+        result[rkey] = relative[rkey];
+    }
+
+    //urlParse appends trailing / to urls like http://www.example.com
+    if (slashedProtocol[result.protocol] &&
+        result.hostname && !result.pathname) {
+      result.path = result.pathname = '/';
+    }
+
+    result.href = result.format();
+    return result;
+  }
+
+  if (relative.protocol && relative.protocol !== result.protocol) {
+    // if it's a known url protocol, then changing
+    // the protocol does weird things
+    // first, if it's not file:, then we MUST have a host,
+    // and if there was a path
+    // to begin with, then we MUST have a path.
+    // if it is file:, then the host is dropped,
+    // because that's known to be hostless.
+    // anything else is assumed to be absolute.
+    if (!slashedProtocol[relative.protocol]) {
+      var keys = Object.keys(relative);
+      for (var v = 0; v < keys.length; v++) {
+        var k = keys[v];
+        result[k] = relative[k];
+      }
+      result.href = result.format();
+      return result;
+    }
+
+    result.protocol = relative.protocol;
+    if (!relative.host && !hostlessProtocol[relative.protocol]) {
+      var relPath = (relative.pathname || '').split('/');
+      while (relPath.length && !(relative.host = relPath.shift()));
+      if (!relative.host) relative.host = '';
+      if (!relative.hostname) relative.hostname = '';
+      if (relPath[0] !== '') relPath.unshift('');
+      if (relPath.length < 2) relPath.unshift('');
+      result.pathname = relPath.join('/');
+    } else {
+      result.pathname = relative.pathname;
+    }
+    result.search = relative.search;
+    result.query = relative.query;
+    result.host = relative.host || '';
+    result.auth = relative.auth;
+    result.hostname = relative.hostname || relative.host;
+    result.port = relative.port;
+    // to support http.request
+    if (result.pathname || result.search) {
+      var p = result.pathname || '';
+      var s = result.search || '';
+      result.path = p + s;
+    }
+    result.slashes = result.slashes || relative.slashes;
+    result.href = result.format();
+    return result;
+  }
+
+  var isSourceAbs = (result.pathname && result.pathname.charAt(0) === '/'),
+      isRelAbs = (
+          relative.host ||
+          relative.pathname && relative.pathname.charAt(0) === '/'
+      ),
+      mustEndAbs = (isRelAbs || isSourceAbs ||
+                    (result.host && relative.pathname)),
+      removeAllDots = mustEndAbs,
+      srcPath = result.pathname && result.pathname.split('/') || [],
+      relPath = relative.pathname && relative.pathname.split('/') || [],
+      psychotic = result.protocol && !slashedProtocol[result.protocol];
+
+  // if the url is a non-slashed url, then relative
+  // links like ../.. should be able
+  // to crawl up to the hostname, as well.  This is strange.
+  // result.protocol has already been set by now.
+  // Later on, put the first path part into the host field.
+  if (psychotic) {
+    result.hostname = '';
+    result.port = null;
+    if (result.host) {
+      if (srcPath[0] === '') srcPath[0] = result.host;
+      else srcPath.unshift(result.host);
+    }
+    result.host = '';
+    if (relative.protocol) {
+      relative.hostname = null;
+      relative.port = null;
+      if (relative.host) {
+        if (relPath[0] === '') relPath[0] = relative.host;
+        else relPath.unshift(relative.host);
+      }
+      relative.host = null;
+    }
+    mustEndAbs = mustEndAbs && (relPath[0] === '' || srcPath[0] === '');
+  }
+
+  if (isRelAbs) {
+    // it's absolute.
+    result.host = (relative.host || relative.host === '') ?
+                  relative.host : result.host;
+    result.hostname = (relative.hostname || relative.hostname === '') ?
+                      relative.hostname : result.hostname;
+    result.search = relative.search;
+    result.query = relative.query;
+    srcPath = relPath;
+    // fall through to the dot-handling below.
+  } else if (relPath.length) {
+    // it's relative
+    // throw away the existing file, and take the new path instead.
+    if (!srcPath) srcPath = [];
+    srcPath.pop();
+    srcPath = srcPath.concat(relPath);
+    result.search = relative.search;
+    result.query = relative.query;
+  } else if (!util.isNullOrUndefined(relative.search)) {
+    // just pull out the search.
+    // like href='?foo'.
+    // Put this after the other two cases because it simplifies the booleans
+    if (psychotic) {
+      result.hostname = result.host = srcPath.shift();
+      //occationaly the auth can get stuck only in host
+      //this especially happens in cases like
+      //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
+      var authInHost = result.host && result.host.indexOf('@') > 0 ?
+                       result.host.split('@') : false;
+      if (authInHost) {
+        result.auth = authInHost.shift();
+        result.host = result.hostname = authInHost.shift();
+      }
+    }
+    result.search = relative.search;
+    result.query = relative.query;
+    //to support http.request
+    if (!util.isNull(result.pathname) || !util.isNull(result.search)) {
+      result.path = (result.pathname ? result.pathname : '') +
+                    (result.search ? result.search : '');
+    }
+    result.href = result.format();
+    return result;
+  }
+
+  if (!srcPath.length) {
+    // no path at all.  easy.
+    // we've already handled the other stuff above.
+    result.pathname = null;
+    //to support http.request
+    if (result.search) {
+      result.path = '/' + result.search;
+    } else {
+      result.path = null;
+    }
+    result.href = result.format();
+    return result;
+  }
+
+  // if a url ENDs in . or .., then it must get a trailing slash.
+  // however, if it ends in anything else non-slashy,
+  // then it must NOT get a trailing slash.
+  var last = srcPath.slice(-1)[0];
+  var hasTrailingSlash = (
+      (result.host || relative.host || srcPath.length > 1) &&
+      (last === '.' || last === '..') || last === '');
+
+  // strip single dots, resolve double dots to parent dir
+  // if the path tries to go above the root, `up` ends up > 0
+  var up = 0;
+  for (var i = srcPath.length; i >= 0; i--) {
+    last = srcPath[i];
+    if (last === '.') {
+      srcPath.splice(i, 1);
+    } else if (last === '..') {
+      srcPath.splice(i, 1);
+      up++;
+    } else if (up) {
+      srcPath.splice(i, 1);
+      up--;
+    }
+  }
+
+  // if the path is allowed to go above the root, restore leading ..s
+  if (!mustEndAbs && !removeAllDots) {
+    for (; up--; up) {
+      srcPath.unshift('..');
+    }
+  }
+
+  if (mustEndAbs && srcPath[0] !== '' &&
+      (!srcPath[0] || srcPath[0].charAt(0) !== '/')) {
+    srcPath.unshift('');
+  }
+
+  if (hasTrailingSlash && (srcPath.join('/').substr(-1) !== '/')) {
+    srcPath.push('');
+  }
+
+  var isAbsolute = srcPath[0] === '' ||
+      (srcPath[0] && srcPath[0].charAt(0) === '/');
+
+  // put the host back
+  if (psychotic) {
+    result.hostname = result.host = isAbsolute ? '' :
+                                    srcPath.length ? srcPath.shift() : '';
+    //occationaly the auth can get stuck only in host
+    //this especially happens in cases like
+    //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
+    var authInHost = result.host && result.host.indexOf('@') > 0 ?
+                     result.host.split('@') : false;
+    if (authInHost) {
+      result.auth = authInHost.shift();
+      result.host = result.hostname = authInHost.shift();
+    }
+  }
+
+  mustEndAbs = mustEndAbs || (result.host && srcPath.length);
+
+  if (mustEndAbs && !isAbsolute) {
+    srcPath.unshift('');
+  }
+
+  if (!srcPath.length) {
+    result.pathname = null;
+    result.path = null;
+  } else {
+    result.pathname = srcPath.join('/');
+  }
+
+  //to support request.http
+  if (!util.isNull(result.pathname) || !util.isNull(result.search)) {
+    result.path = (result.pathname ? result.pathname : '') +
+                  (result.search ? result.search : '');
+  }
+  result.auth = relative.auth || result.auth;
+  result.slashes = result.slashes || relative.slashes;
+  result.href = result.format();
+  return result;
+};
+
+Url.prototype.parseHost = function() {
+  var host = this.host;
+  var port = portPattern.exec(host);
+  if (port) {
+    port = port[0];
+    if (port !== ':') {
+      this.port = port.substr(1);
+    }
+    host = host.substr(0, host.length - port.length);
+  }
+  if (host) this.hostname = host;
+};
+
+},{"./util":8,"punycode":3,"querystring":6}],8:[function(require,module,exports){
+'use strict';
+
+module.exports = {
+  isString: function(arg) {
+    return typeof(arg) === 'string';
+  },
+  isObject: function(arg) {
+    return typeof(arg) === 'object' && arg !== null;
+  },
+  isNull: function(arg) {
+    return arg === null;
+  },
+  isNullOrUndefined: function(arg) {
+    return arg == null;
+  }
+};
 
 },{}]},{},[1]);

--- a/formspree/static/js/bundle.js
+++ b/formspree/static/js/bundle.js
@@ -1,0 +1,82 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+const $ = window.$
+const StripeCheckout = window.StripeCheckout
+const toastr = window.toastr
+
+/* top navbar */
+var nav = $('body > nav')
+nav.addClass('js')
+nav.find('.menu').slicknav()
+nav.find('h4').clone().prependTo('.slicknav_menu')
+
+/* adding a shadow at the bottom of the menu bar only when not at the top */
+var w = $(window)
+w.scroll(function () {
+  var scrollPos = w.scrollTop()
+  if (scrollPos && !nav.hasClass('scrolled')) {
+    nav.addClass('scrolled')
+  } else if (!scrollPos) {
+    nav.removeClass('scrolled')
+  }
+})
+
+/* background-color should inherit, but CSS's "inherit" breaks z-index */
+var bgcolor = $(document.body).css('background-color')
+if (bgcolor.split(',').length === 4 || bgcolor === 'transparent') {
+  bgcolor = 'white'
+}
+nav.css('background-color', bgcolor)
+
+/* modal */
+$('.modal').each(function () {
+  var modal = $(this)
+  modal.addClass('js')
+  var id = modal.attr('id')
+  $('[href="#' + id + '"]').click(function (e) {
+    e.preventDefault()
+    modal.toggleClass('target')
+  })
+  modal.click(function (e) {
+    if (e.target === modal[0]) {
+      modal.toggleClass('target')
+      e.preventDefault()
+    }
+  })
+  modal.find('.x a').click(function (e) {
+    e.preventDefault()
+    modal.toggleClass('target')
+  })
+})
+
+/* turning flask flash messages into js popup notifications */
+toastr.options = { positionClass: 'toast-top-center' }
+window.popupMessages.forEach(function (m, i) {
+  var category = m[0] || 'info'
+  var text = m[1]
+  setTimeout(function () { toastr[category](text) }, (1 + i) * 1500)
+})
+
+/* stripe checkout */
+var stripebutton = $('#stripe-upgrade')
+if (stripebutton.length) {
+  var handler = StripeCheckout.configure(stripebutton.data())
+  stripebutton.on('click', function (e) {
+    handler.open({
+      token: function (token) {
+        stripebutton.closest('form')
+          .append(`<input type="hidden" name="stripeToken" value="${token.id}">`)
+          .append(`<input type="hidden" name="stripeEmail" value="${token.email}">`)
+          .submit()
+      }
+    })
+    e.preventDefault()
+  })
+}
+
+/* quick script for showing the resend confirmation form */
+$('a.resend').on('click', function () {
+  $(this).hide()
+  $('form.resend').show()
+})
+
+},{}]},{},[1]);

--- a/formspree/static/js/main.js
+++ b/formspree/static/js/main.js
@@ -1,0 +1,79 @@
+const $ = window.$
+const StripeCheckout = window.StripeCheckout
+const toastr = window.toastr
+
+/* top navbar */
+var nav = $('body > nav')
+nav.addClass('js')
+nav.find('.menu').slicknav()
+nav.find('h4').clone().prependTo('.slicknav_menu')
+
+/* adding a shadow at the bottom of the menu bar only when not at the top */
+var w = $(window)
+w.scroll(function () {
+  var scrollPos = w.scrollTop()
+  if (scrollPos && !nav.hasClass('scrolled')) {
+    nav.addClass('scrolled')
+  } else if (!scrollPos) {
+    nav.removeClass('scrolled')
+  }
+})
+
+/* background-color should inherit, but CSS's "inherit" breaks z-index */
+var bgcolor = $(document.body).css('background-color')
+if (bgcolor.split(',').length === 4 || bgcolor === 'transparent') {
+  bgcolor = 'white'
+}
+nav.css('background-color', bgcolor)
+
+/* modal */
+$('.modal').each(function () {
+  var modal = $(this)
+  modal.addClass('js')
+  var id = modal.attr('id')
+  $('[href="#' + id + '"]').click(function (e) {
+    e.preventDefault()
+    modal.toggleClass('target')
+  })
+  modal.click(function (e) {
+    if (e.target === modal[0]) {
+      modal.toggleClass('target')
+      e.preventDefault()
+    }
+  })
+  modal.find('.x a').click(function (e) {
+    e.preventDefault()
+    modal.toggleClass('target')
+  })
+})
+
+/* turning flask flash messages into js popup notifications */
+toastr.options = { positionClass: 'toast-top-center' }
+window.popupMessages.forEach(function (m, i) {
+  var category = m[0] || 'info'
+  var text = m[1]
+  setTimeout(function () { toastr[category](text) }, (1 + i) * 1500)
+})
+
+/* stripe checkout */
+var stripebutton = $('#stripe-upgrade')
+if (stripebutton.length) {
+  var handler = StripeCheckout.configure(stripebutton.data())
+  stripebutton.on('click', function (e) {
+    handler.open({
+      token: function (token) {
+        stripebutton.closest('form')
+          .append(`<input type="hidden" name="stripeToken" value="${token.id}">`)
+          .append(`<input type="hidden" name="stripeEmail" value="${token.email}">`)
+          .submit()
+      }
+    })
+    e.preventDefault()
+  })
+}
+
+/* quick script for showing the resend confirmation form */
+$('a.resend').on('click', function () {
+  $(this).hide()
+  $('form.resend').show()
+})

--- a/formspree/static/js/main.js
+++ b/formspree/static/js/main.js
@@ -1,6 +1,11 @@
+const url = require('url')
+const isValidEmail = require('is-valid-email')
+
 const $ = window.$
 const StripeCheckout = window.StripeCheckout
 const toastr = window.toastr
+
+toastr.options = { positionClass: 'toast-top-center' }
 
 /* top navbar */
 var nav = $('body > nav')
@@ -47,8 +52,71 @@ $('.modal').each(function () {
   })
 })
 
+/* create-form validation for site-wide forms */
+function sitewide () {
+  let createform = $('#create-form')
+  let emailInput = createform.find('input[name="email"]')
+  let urlInput = createform.find('input[name="url"]')
+  let checkbox = createform.find('input[name="sitewide"]')
+  let verifyButton = createform.find('.verify-button')
+  let createButton = createform.find('.create-button')
+  let info = createform.find('.verify-info')
+
+  checkbox.on('change', run)
+  emailInput.on('input', run)
+  urlInput.on('input', run)
+
+  function run () {
+    if (checkbox.is(':checked')) {
+      let email = emailInput.val().trim()
+      let urlp = url.parse(urlInput.val().trim())
+
+      if (isValidEmail(email) && urlp.host) {
+        let sitewideFile = `formspree_verify_${email}.txt`
+        verifyButton.css('visibility', 'visible')
+        info.html(`Please ensure <span class="code">${url.resolve(urlInput.val(), '/' + sitewideFile)}</span> exists`)
+      } else {
+        // wrong input
+        if (!urlp.host) { // invalid url
+          info.text('Please input a valid URL.')
+        } else { // invalid email
+          info.text('Please input a valid email address.')
+        }
+      }
+
+      createButton.find('button').prop('disabled', true)
+      info.css('visibility', 'visible')
+    } else {
+      // toggle sitewide off
+      info.css('visibility', 'hidden')
+      verifyButton.css('visibility', 'hidden')
+      createButton.css('visibility', 'visible')
+    }
+  }
+
+  verifyButton.find('button').on('click', function () {
+    $.ajax({
+      url: '/forms/sitewide-check?' + createform.find('form').serialize(),
+      success: function () {
+        toastr.success('The file exists! you can create your site-wide form now.')
+        createButton.find('button').prop('disabled', false)
+        verifyButton.css('visibility', 'hidden')
+        info.css('visibility', 'hidden')
+      },
+      error: function () {
+        toastr.warning("The verification file wasn't found.")
+        verifyButton.find('button').prop('disabled', true)
+        setTimeout(() => {
+          verifyButton.find('button').prop('disabled', false)
+        }, 5000)
+      }
+    })
+    return false
+  })
+}
+sitewide()
+
 /* turning flask flash messages into js popup notifications */
-toastr.options = { positionClass: 'toast-top-center' }
 window.popupMessages.forEach(function (m, i) {
   var category = m[0] || 'info'
   var text = m[1]

--- a/formspree/static/scss/dashboard.scss
+++ b/formspree/static/scss/dashboard.scss
@@ -73,12 +73,12 @@
     form input {
       margin-top:0;
       clear: both;
-      width: 70%;
+      width: 100%;
       vertical-align: top;
     }
     form button {
-      padding: 0.63em;
-      width: 27%;
+      padding: 0.63em 32px;
+      text-align: center;
     }
   
     .modal:not(.js):target > *,
@@ -119,8 +119,7 @@
         padding: 10px;
         font-size: 1.7em;
       }
-      .x h4 {
-        float: left;
+      h4 {
         margin: 0;
         padding: 0;
         margin-top: 13px;

--- a/formspree/static/scss/dashboard.scss
+++ b/formspree/static/scss/dashboard.scss
@@ -1,3 +1,13 @@
+.highlight {
+  padding: 2px 6px;
+  font-weight: bold;
+  font-size: 20px;
+  color: white;
+  background-color: #35918D;
+  border-radius: 3px;
+  margin: 3px;
+}
+
 .login {
   .row { padding: 2.2em 0 }
 
@@ -70,7 +80,7 @@
     margin: 3em 0;
   
     form { clear: both; }
-    form input {
+    form input:not([type="checkbox"]):not([type="radio"]) {
       margin-top:0;
       clear: both;
       width: 100%;
@@ -79,6 +89,10 @@
     form button {
       padding: 0.63em 32px;
       text-align: center;
+    }
+
+    .verify-info {
+      font-size: 13px;
     }
   
     .modal:not(.js):target > *,

--- a/formspree/static/scss/main.scss
+++ b/formspree/static/scss/main.scss
@@ -230,6 +230,11 @@ button, a.button {
             background-color: $dark-green;
         }
     }
+    &[disabled],
+    &[disabled]:hover {
+      color: lighten($green, 40%);
+      border-color: lighten($green, 40%);
+    }
 }
 
 

--- a/formspree/templates/forms/create.html
+++ b/formspree/templates/forms/create.html
@@ -6,11 +6,26 @@
     </a>
   
     <div class="modal" id="create-form" aria-hidden="true">
-      <div>
-        <div class="x"><h4>Send email to:</h4><a href="#">&times;</a></div>
-        <form method="POST" action="{{ url_for('forms') }}">
-          <input type="email" name="email" placeholder="You can point this form to any email address" value="{{ current_user.email }}">
-          <button type="submit">Create</button>
+      <div class="container">
+        <div class="x"><a href="#">&times;</a></div>
+        <form method="POST" action="{{ url_for('create-form') }}">
+          <div class="col-1-1">
+            <h4>Send email to:</h4>
+            <input type="email" name="email" placeholder="You can point this form to any email address" value="{{ current_user.email }}">
+          </div>
+          <div class="col-1-1">
+            <h4>From URL:</h4>
+            <input type="url" name="url" placeholder="Leave blank to send confirmation email when first submitted">
+          </div>
+          <div class="col-1-3">
+            &#8203;
+          </div>
+          <div class="col-1-3">
+            &#8203;
+          </div>
+          <div class="col-1-3">
+            <button type="submit">Create form</button>
+          </div>
         </form>
       </div>
     </div>

--- a/formspree/templates/forms/create.html
+++ b/formspree/templates/forms/create.html
@@ -17,14 +17,32 @@
             <h4>From URL:</h4>
             <input type="url" name="url" placeholder="Leave blank to send confirmation email when first submitted">
           </div>
+          <div class="container">
+            <div class="col-1-4">
+              <label class="hint--bottom" data-hint="A site-wide form is a form that you can place on all pages of your website -- and you just have to confirm once!">
+                <input type="checkbox" name="sitewide" value="true">
+                site-wide
+              </label>
+            </div>
+            <div class="col-3-4">
+              <div class="verify-info" style="visibility: hidden"></div>
+              <noscript>
+                When creating a form that is valid site-wide, ensure you have a file at the root of your site that matches the pattern <span class="code">/formspree_verify_emailaddress@provider.com</span>
+              </noscript>
+            </div>
+          </div>
           <div class="col-1-3">
-            &#8203;
+            <div class="verify-button" style="visibility: hidden">
+              <button>Verify</button>
+            </div>
           </div>
           <div class="col-1-3">
             &#8203;
           </div>
           <div class="col-1-3">
-            <button type="submit">Create form</button>
+            <div class="create-button">
+              <button type="submit">Create form</button>
+            </div>
           </div>
         </form>
       </div>

--- a/formspree/templates/forms/list.html
+++ b/formspree/templates/forms/list.html
@@ -25,6 +25,9 @@
           <a href="#view-code-{{ form.hashid }}">View HTML code</a>
         {% else %}
           {{ form.host }}
+          {% if form.sitewide %}
+            <span class="highlight tooltip hint--top" data-hint="This form works for all paths under {{ form.host }}/">/ *</span>
+          {% endif %}
         {% endif %}
       </td>
       <td><span class="hint--top" data-hint="{{ request.url_root.replace('http://', 'https://') }}{% if form.hash %}{{ form.email }}{% else %}{{ form.hashid }}{% endif %}">{{ form.email }}</span></td>

--- a/formspree/templates/forms/submissions.html
+++ b/formspree/templates/forms/submissions.html
@@ -14,7 +14,7 @@
       {% else %}
         <span class="code">/{{ form.email }}</span>
       {% endif %}
-      at <span class="code">{{ form.host }}</span>
+      at <span class="code">{{ form.host }}</span>{% if form.sitewide %} and all its subpaths.{% endif %}
       {% if not form.hash %}
         <br><small>targeting <span class="code">{{ form.email }}</span></small>
       {% else %}

--- a/formspree/templates/layouts/base.html
+++ b/formspree/templates/layouts/base.html
@@ -62,88 +62,12 @@
 
   <script src="{{ url_for('static', filename='js/vendor/jquery.min.js') }}"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/SlickNav/1.0.3/jquery.slicknav.min.js"></script>
-  <script>
-    /* top navbar */
-    var nav = $('body > nav')
-    nav.addClass('js')
-    nav.find('.menu').slicknav()
-    nav.find('h4').clone().prependTo('.slicknav_menu')
-
-    /* adding a shadow at the bottom of the menu bar only when not at the top */
-    var w = $(window)
-    w.scroll(function () {
-      var scrollPos = w.scrollTop()
-      if (scrollPos && !nav.hasClass('scrolled')) {
-        nav.addClass('scrolled')
-      }
-      else if (!scrollPos) {
-        nav.removeClass('scrolled')
-      }
-    })
-
-    /* background-color should inherit, but CSS's "inherit" breaks z-index */
-    var bgcolor = $(document.body).css('background-color')
-    if (bgcolor.split(',').length == 4 || bgcolor == 'transparent') {
-      bgcolor = 'white'
-    }
-    nav.css('background-color', bgcolor)
-
-    /* modal */
-    $('.modal').each(function () {
-        var modal = $(this)
-        modal.addClass('js')
-        var id = modal.attr('id')
-        $('[href="#' + id + '"]').click(function (e) {
-          e.preventDefault()
-          modal.toggleClass('target')
-        })
-        modal.click(function (e) {
-          if (e.target == modal[0]) {
-            modal.toggleClass('target')
-            e.preventDefault()
-          }
-        })
-        modal.find('.x a').click(function (e) {
-          e.preventDefault()
-          modal.toggleClass('target')
-        })
-    })
-  </script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.1/toastr.min.js"></script>
   <script>
     /* turning flask flash messages into js popup notifications */
-    var messages = {{ get_flashed_messages(with_categories=True) | json | safe }}
-    toastr.options = { positionClass: 'toast-top-center' }
-    messages.forEach(function (m, i) {
-      var category = m[0] || 'info'
-      var text = m[1]
-      setTimeout(function () { toastr[category](text) }, (1+i)*1500)
-    })
+    window.popupMessages = {{ get_flashed_messages(with_categories=True) | json | safe }}
   </script>
   <script src="https://checkout.stripe.com/checkout.js"></script>
-  <script>
-    var stripebutton = $('#stripe-upgrade')
-    if (stripebutton.length) {
-      var handler = StripeCheckout.configure(stripebutton.data())
-      stripebutton.on('click', function (e) {
-        handler.open({
-          token: function (token) {
-            stripebutton.closest('form')
-              .append('<input type="hidden" name="stripeToken" value="'+ token.id +'">')
-              .append('<input type="hidden" name="stripeEmail" value="'+ token.email +'">')
-              .submit()
-          }
-        })
-        e.preventDefault()
-      })
-    }
-
-    /* quick script for showing the resend confirmation form */
-    $('a.resend').on('click', function () {
-      $(this).hide()
-      $('form.resend').show()
-    })
-  </script>
-
+  <script src="{{ url_for('static', filename='js/bundle.js') }}"></script>
 </body>
 </html>

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -208,7 +208,7 @@
       <div class="container narrow block">
             <div class="col-1-1">
                 <h3>Invisible emails</h3>
-                <p>Through our dashboard, you will be able to get a random-like string to replace your naked email address in the <span class="code">action</span> attribute of your form. Your email address will remain unknown to spam-bots and also your human visitors.</p>
+                <p>Get a random-like string to replace your naked email address in the <span class="code">action</span> attribute of your form. Your email address will remain unknown to spam-bots and human visitors.</p>
             </div>
       </div>
 
@@ -216,6 +216,20 @@
             <div class="col-1-1">
                 <h3>Unlimited form submissions</h3>
                 <p>Getting more than 1000 submissions each month? No problem, upgrading will cover that.</p>
+            </div>
+      </div>
+
+      <div class="container narrow block">
+            <div class="col-1-1">
+                <h3>Same form on multiple pages</h3>
+                <p>Showing the same form on many different pages? Generate a form verified site-wide and don't worry about having to track multiple confirmation emails.</p>
+            </div>
+      </div>
+
+      <div class="container narrow block">
+            <div class="col-1-1">
+                <h3>Auto-confirmed forms</h3>
+                <p>Pre-verify email addresses on your account and you'll be able to create forms targetting them without having to submit the form and click on confirmation links.</p>
             </div>
       </div>
 

--- a/formspree/templates/users/dashboard.html
+++ b/formspree/templates/users/dashboard.html
@@ -19,7 +19,7 @@
   <div class="row section grey">
     <div class="container narrow block">
         <div class="col-1-2">
-          <p>{{config.SERVICE_NAME}} is a tool maintained by the <a href="http://assembly.com/formspree">community at Assembly</a>. To contact us send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a> or use the form on the right.</p>
+          <p>{{config.SERVICE_NAME}} is a tool <a href="https://github.com/formspree/formspree">managed on GitHub</a>. To contact us send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a> or use the form on the right.</p>
         </div>
         <div class="col-1-2">
           <form method="POST" action="//{{config.API_ROOT}}/{{config.CONTACT_EMAIL}}">

--- a/formspree/utils.py
+++ b/formspree/utils.py
@@ -16,7 +16,8 @@ IS_VALID_EMAIL = lambda x: re.match(r"[^@]+@[^@]+\.[^@]+", x)
 # decorators
 
 def request_wants_json():
-    if request.headers.get('X_REQUESTED_WITH','').lower() == 'xmlhttprequest':
+    if request.headers.get('X_REQUESTED_WITH','').lower() == 'xmlhttprequest' or \
+       request.headers.get('X-REQUESTED-WITH','').lower() == 'xmlhttprequest':
         return True
     if accept_better('json', 'html'):
         return True

--- a/migrations/versions/ee9b6bc06d8a_sitewide_forms.py
+++ b/migrations/versions/ee9b6bc06d8a_sitewide_forms.py
@@ -1,0 +1,22 @@
+"""sitewide forms.
+
+Revision ID: ee9b6bc06d8a
+Revises: 2580663da150
+Create Date: 2016-03-07 19:59:20.392152
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'ee9b6bc06d8a'
+down_revision = '2580663da150'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('forms', sa.Column('sitewide', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('forms', 'sitewide')

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build-js": "browserify formspree/static/js/main.js --outfile formspree/static/js/bundle.js",
-    "build": "npm run build-js"
+    "build-css": "scss --sourcemap=none formspree/static/scss/main.scss formspree/static/css/main.css",
+    "build": "npm run build-js && npm run build-css"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,13 @@
 {
-  "dependencies": {},
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
+  },
+  "dependencies": {
+    "is-valid-email": "0.0.2",
+    "url": "^0.11.0"
+  },
   "devDependencies": {
     "babel-core": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
@@ -7,7 +15,7 @@
     "browserify": "^13.0.0"
   },
   "scripts": {
-    "build-js": "browserify formspree/static/js/main.js --outfile formspree/static/js/bundle.js",
+    "build-js": "browserify formspree/static/js/main.js -t babelify --outfile formspree/static/js/bundle.js",
     "build-css": "scss --sourcemap=none formspree/static/scss/main.scss formspree/static/css/main.css",
     "build": "npm run build-js && npm run build-css"
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {},
+  "devDependencies": {
+    "babel-core": "^6.6.5",
+    "babel-preset-es2015": "^6.6.0",
+    "babelify": "^7.2.0",
+    "browserify": "^13.0.0"
+  },
+  "scripts": {
+    "build-js": "browserify formspree/static/js/main.js --outfile formspree/static/js/bundle.js",
+    "build": "npm run build-js"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ python-dotenv
 gunicorn
 psycopg2
 stripe
-httpretty
+httpretty==0.8.3
 fakeredis
 redis
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ python-dotenv
 gunicorn
 psycopg2
 stripe
-httpretty==0.8.3
+httpretty==0.8.14
 fakeredis
 redis
 mock

--- a/tests/test_form_creation.py
+++ b/tests/test_form_creation.py
@@ -1,0 +1,149 @@
+import httpretty
+import json
+
+from formspree import settings
+from formspree.app import DB
+from formspree.forms.helpers import HASH
+from formspree.users.models import User, Email
+from formspree.forms.models import Form
+
+from formspree_test_case import FormspreeTestCase
+from utils import parse_confirmation_link_sent
+
+class TestFormCreationFromDashboard(FormspreeTestCase):
+
+    @httpretty.activate
+    def test_form_creation(self):
+        httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
+
+        # register user
+        r = self.client.post('/register',
+            data={'email': 'colorado@springs.com',
+                  'password': 'banana'}
+        )
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(1, User.query.count())
+
+        # fail to create form
+        r = self.client.post('/forms',
+            headers={'Content-type': 'application/json'},
+            data={'email': 'hope@springs.com'}
+        )
+        self.assertEqual(r.status_code, 402)
+        self.assertIn('error', json.loads(r.data))
+        self.assertEqual(0, Form.query.count())
+
+        # upgrade user manually
+        user = User.query.filter_by(email='colorado@springs.com').first()
+        user.upgraded = True
+        DB.session.add(user)
+        DB.session.commit()
+
+        # successfully create form
+        r = self.client.post('/forms',
+            headers={'Accept': 'application/json', 'Content-type': 'application/json'},
+            data=json.dumps({'email': 'hope@springs.com'})
+        )
+        resp = json.loads(r.data)
+        self.assertEqual(r.status_code, 200)
+        self.assertIn('submission_url', resp)
+        self.assertIn('hashid', resp)
+        form_endpoint = resp['hashid']
+        self.assertIn(resp['hashid'], resp['submission_url'])
+        self.assertEqual(1, Form.query.count())
+        self.assertEqual(Form.query.first().id, Form.get_with_hashid(resp['hashid']).id)
+
+        # post to form
+        r = self.client.post('/' + form_endpoint,
+            headers={'Referer': 'formspree.io'},
+            data={'name': 'bruce'}
+        )
+        self.assertIn("We've sent a link to your email", r.data)
+        self.assertIn('confirm+your+email', httpretty.last_request().body)
+        self.assertEqual(1, Form.query.count())
+
+        # confirm form
+        form = Form.query.first()
+        self.client.get('/confirm/%s:%s' % (HASH(form.email, str(form.id)), form.hashid))
+        self.assertTrue(Form.query.first().confirmed)
+
+        # send 5 forms (monthly limits should not apply to the upgraded user)
+        self.assertEqual(settings.MONTHLY_SUBMISSIONS_LIMIT, 2)
+        for i in range(5):
+            r = self.client.post('/' + form_endpoint,
+                headers={'Referer': 'formspree.io'},
+                data={'name': 'ana',
+                      'submission': '__%s__' % i}
+            )
+        form = Form.query.first()
+        self.assertEqual(form.counter, 5)
+        self.assertEqual(form.get_monthly_counter(), 5)
+        self.assertIn('ana', httpretty.last_request().body)
+        self.assertIn('__4__', httpretty.last_request().body)
+        self.assertNotIn('You+are+past+our+limit', httpretty.last_request().body)
+
+        # try (and fail) to submit from a different host
+        r = self.client.post('/' + form_endpoint,
+            headers={'Referer': 'bad.com'},
+            data={'name': 'usurper'}
+        )
+        self.assertEqual(r.status_code, 403)
+        self.assertIn('ana', httpretty.last_request().body) # no more data is sent to sendgrid
+        self.assertIn('__4__', httpretty.last_request().body)
+
+    @httpretty.activate
+    def test_form_creation_without_a_registered_email(self):
+        httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
+
+        # register user
+        r = self.client.post('/register',
+            data={'email': 'user@formspree.io',
+                  'password': 'banana'}
+        )
+        # upgrade user manually
+        user = User.query.filter_by(email='user@formspree.io').first()
+        user.upgraded = True
+        DB.session.add(user)
+        DB.session.commit()
+
+        # create form without providing an url should not send verification email
+        httpretty.reset()
+        r = self.client.post('/forms',
+            headers={'Accept': 'application/json', 'Content-type': 'application/json'},
+            data=json.dumps({'email': 'email@formspree.io'})
+        )
+        self.assertEqual(httpretty.has_request(), False)
+
+        # create form without a confirmed email should send a verification email
+        httpretty.reset()
+        r = self.client.post('/forms',
+            headers={'Accept': 'application/json', 'Content-type': 'application/json'},
+            data=json.dumps({'email': 'email@formspree.io',
+                             'url': 'https://www.testsite.com/contact.html'})
+        )
+        resp = json.loads(r.data)
+        self.assertEqual(resp['confirmed'], False)
+        self.assertEqual(httpretty.has_request(), True)
+        self.assertIn('Confirm+email', httpretty.last_request().body)
+        self.assertIn('www.testsite.com%2Fcontact.html', httpretty.last_request().body)
+
+        # manually verify an email
+        email = Email()
+        email.address = 'owned-by@formspree.io'
+        email.owner_id = user.id
+        DB.session.add(email)
+        DB.session.commit()
+
+        # create a form with the verified email address
+        httpretty.reset()
+        r = self.client.post('/forms',
+            headers={'Accept': 'application/json', 'Content-type': 'application/json'},
+            data=json.dumps({'email': 'owned-by@formspree.io',
+                             'url': 'https://www.testsite.com/about.html'})
+        )
+        resp = json.loads(r.data)
+        self.assertEqual(resp['confirmed'], True)
+        self.assertEqual(httpretty.has_request(), False)
+
+        # should have three created forms in the end
+        self.assertEqual(Form.query.count(), 3)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -63,85 +63,6 @@ class UserAccountsTestCase(FormspreeTestCase):
         self.assertTrue(r.location.endswith('/dashboard'))
         self.assertEqual(1, User.query.count())
 
-    @httpretty.activate
-    def test_form_creation(self):
-        httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
-
-        # register user
-        r = self.client.post('/register',
-            data={'email': 'colorado@springs.com',
-                  'password': 'banana'}
-        )
-        self.assertEqual(r.status_code, 302)
-        self.assertEqual(1, User.query.count())
-
-        # fail to create form
-        r = self.client.post('/forms',
-            headers={'Content-type': 'application/json'},
-            data={'email': 'hope@springs.com'}
-        )
-        self.assertEqual(r.status_code, 402)
-        self.assertIn('error', json.loads(r.data))
-        self.assertEqual(0, Form.query.count())
-
-        # upgrade user manually
-        user = User.query.filter_by(email='colorado@springs.com').first()
-        user.upgraded = True
-        DB.session.add(user)
-        DB.session.commit()
-
-        # successfully create form
-        r = self.client.post('/forms',
-            headers={'Accept': 'application/json', 'Content-type': 'application/json'},
-            data=json.dumps({'email': 'hope@springs.com'})
-        )
-        resp = json.loads(r.data)
-        self.assertEqual(r.status_code, 200)
-        self.assertIn('submission_url', resp)
-        self.assertIn('hashid', resp)
-        form_endpoint = resp['hashid']
-        self.assertIn(resp['hashid'], resp['submission_url'])
-        self.assertEqual(1, Form.query.count())
-        self.assertEqual(Form.query.first().id, Form.get_with_hashid(resp['hashid']).id)
-
-        # post to form
-        r = self.client.post('/' + form_endpoint,
-            headers={'Referer': 'formspree.io'},
-            data={'name': 'bruce'}
-        )
-        self.assertIn("We've sent a link to your email", r.data)
-        self.assertIn('confirm+your+email', httpretty.last_request().body)
-        self.assertEqual(1, Form.query.count())
-
-        # confirm form
-        form = Form.query.first()
-        self.client.get('/confirm/%s:%s' % (HASH(form.email, str(form.id)), form.hashid))
-        self.assertTrue(Form.query.first().confirmed)
-
-        # send 5 forms (monthly limits should not apply to the upgraded user)
-        self.assertEqual(settings.MONTHLY_SUBMISSIONS_LIMIT, 2)
-        for i in range(5):
-            r = self.client.post('/' + form_endpoint,
-                headers={'Referer': 'formspree.io'},
-                data={'name': 'ana',
-                      'submission': '__%s__' % i}
-            )
-        form = Form.query.first()
-        self.assertEqual(form.counter, 5)
-        self.assertEqual(form.get_monthly_counter(), 5)
-        self.assertIn('ana', httpretty.last_request().body)
-        self.assertIn('__4__', httpretty.last_request().body)
-        self.assertNotIn('You+are+past+our+limit', httpretty.last_request().body)
-
-        # try (and fail) to submit from a different host
-        r = self.client.post('/' + form_endpoint,
-            headers={'Referer': 'bad.com'},
-            data={'name': 'usurper'}
-        )
-        self.assertEqual(r.status_code, 403)
-        self.assertIn('ana', httpretty.last_request().body) # no more data is sent to sendgrid
-        self.assertIn('__4__', httpretty.last_request().body)
-
     def test_user_upgrade_and_downgrade(self):
         # check correct usage of stripe test keys during test
         self.assertIn('_test_', settings.STRIPE_PUBLISHABLE_KEY)
@@ -204,5 +125,3 @@ class UserAccountsTestCase(FormspreeTestCase):
 
         # delete the stripe customer
         customer.delete()
-
-


### PR DESCRIPTION
**New feature**

**Changes proposed in this pull request:**

* The form creation API now supports creating forms that are pre-confirmed if the target email was already verified for the user account.
* The form creation API now supports creating forms verified site-wide. At the moment of the form creation an HTTP request is made to check for the presence of a verification file at the root path of the site that is being authorized.
* Adds a new boolean column to the `forms` table, named "sitewide".

**Have you made sure to add:**
- [x] Tests
- [ ] Documentation

**Demo**

http://formspree-fiatjaf.herokuapp.com/ (say your registered email there if you want a Gold account to test)

**Deploy notes**

Database migration: `heroku run python manage.py db upgrade --app formspree-asm`