### PR TITLE
Multiple cc

### DIFF
--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -8,7 +8,7 @@ import hashlib
 import hashids
 
 HASH = lambda x, y: hashlib.md5(x+y+settings.NONCE_SECRET).hexdigest()
-EXCLUDE_KEYS = ['_gotcha', '_next', '_subject', '_cc', '_bcc', '_format']
+EXCLUDE_KEYS = ['_gotcha', '_next', '_subject', '_cc', '_bcc']
 MONTHLY_COUNTER_KEY = 'monthly_{form_id}_{month}'.format
 HASHIDS_CODEC = hashids.Hashids(alphabet='abcdefghijklmnopqrstuvwxyz',
                                 min_length=8,

--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -8,7 +8,7 @@ import hashlib
 import hashids
 
 HASH = lambda x, y: hashlib.md5(x+y+settings.NONCE_SECRET).hexdigest()
-EXCLUDE_KEYS = ['_gotcha', '_next', '_subject', '_cc', '_bcc']
+EXCLUDE_KEYS = ['_gotcha', '_next', '_subject', '_cc']
 MONTHLY_COUNTER_KEY = 'monthly_{form_id}_{month}'.format
 HASHIDS_CODEC = hashids.Hashids(alphabet='abcdefghijklmnopqrstuvwxyz',
                                 min_length=8,

--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -8,7 +8,7 @@ import hashlib
 import hashids
 
 HASH = lambda x, y: hashlib.md5(x+y+settings.NONCE_SECRET).hexdigest()
-EXCLUDE_KEYS = ['_gotcha', '_next', '_subject', '_cc']
+EXCLUDE_KEYS = ['_gotcha', '_next', '_subject', '_cc', '_bcc', '_format']
 MONTHLY_COUNTER_KEY = 'monthly_{form_id}_{month}'.format
 HASHIDS_CODEC = hashids.Hashids(alphabet='abcdefghijklmnopqrstuvwxyz',
                                 min_length=8,

--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -107,11 +107,12 @@ class Form(DB.Model):
         bcc = data.get('_bcc', None)
         next = next_url(referrer, data.get('_next'))
         spam = data.get('_gotcha', None)
-        format = data.get('_format', None)
+
+		# turn cc and bcc emails into array
         if cc:
-			cc = [email.strip() for email in cc.split(',')]
+            cc = [email.strip() for email in cc.split(',')]
         if bcc:
-			bcc = [email.strip() for email in bcc.split(',')]
+            bcc = [email.strip() for email in bcc.split(',')]
 
         # prevent submitting empty form
         if not any(data.values()):
@@ -161,11 +162,7 @@ class Form(DB.Model):
         now = datetime.datetime.utcnow().strftime('%I:%M %p UTC - %d %B %Y')
         if not overlimit:
             text = render_template('email/form.txt', data=data, host=self.host, keys=keys, now=now)
-            # check if the user wants a new or old version of the email
-            if format == 'text':
-                html = render_template('email/text_form.html', data=data, host=self.host, keys=keys, now=now)
-            else:
-                html = render_template('email/form.html', data=data, host=self.host, keys=keys, now=now)
+            html = render_template('email/form.html', data=data, host=self.host, keys=keys, now=now)
         else:
             if monthly_counter - settings.MONTHLY_SUBMISSIONS_LIMIT > 25:
                 # only send this overlimit notification for the first 25 overlimit emails

--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -104,15 +104,12 @@ class Form(DB.Model):
         subject = data.get('_subject', 'New submission from %s' % referrer_to_path(referrer))
         reply_to = data.get('_replyto', data.get('email', data.get('Email', None)))
         cc = data.get('_cc', None)
-        bcc = data.get('_bcc', None)
         next = next_url(referrer, data.get('_next'))
         spam = data.get('_gotcha', None)
 
-		# turn cc and bcc emails into array
+		# turn cc emails into array
         if cc:
             cc = [email.strip() for email in cc.split(',')]
-        if bcc:
-            bcc = [email.strip() for email in bcc.split(',')]
 
         # prevent submitting empty form
         if not any(data.values()):

--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -151,6 +151,14 @@ class Form(DB.Model):
                         overlimit = False
                         break
 
+		# check if user wants to cc multiple email addresses
+		if cc.index(',') != -1:
+			emails = [email.strip() for email in cc.split(',')]
+			all_emails = ""
+			for email in emails:
+				all_emails += "cc[]=%s&" % email
+			cc = all_emails[:-1]
+
         now = datetime.datetime.utcnow().strftime('%I:%M %p UTC - %d %B %Y')
         if not overlimit:
             text = render_template('email/form.txt', data=data, host=self.host, keys=keys, now=now)

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -154,16 +154,6 @@
 
       <div class="container narrow block">
             <div class="col-1-1">
-                <h4><span class="code">_bcc</span></h4>
-                <p>This value is used for the email's BCC Field. This lets you send a copy of each submission to another email address.</p>
-                <p><input type="text" class="code" value='<input type="hidden" name="_bcc" value="another@email.com" />'></p>
-				<p>If you want to BCC multiple email addresses, then just make it a list of email addresses separate by commas.</p>
-                <p><input type="text" class="code" value='<input type="hidden" name="_bcc" value="another@email.com,yetanother@email.com" />'></p>
-            </div>
-      </div>
-
-      <div class="container narrow block">
-            <div class="col-1-1">
                 <h4><span class="code">_gotcha</span></h4>
                 <p>Add this "honeypot" field to avoid spam by fooling scrapers. If a value is provided, the submission will be silently ignored. The input should be hidden with CSS.</p>
                 <p><input type="text" class="code" value='<input type="text" name="_gotcha" style="display:none" />'></p>

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -147,6 +147,18 @@
                 <h4><span class="code">_cc</span></h4>
                 <p>This value is used for the email's CC Field. This lets you send a copy of each submission to another email address.</p>
                 <p><input type="text" class="code" value='<input type="hidden" name="_cc" value="another@email.com" />'></p>
+				<p>If you want to CC multiple email addresses, then just make it a list of email addresses separate by commas.</p>
+                <p><input type="text" class="code" value='<input type="hidden" name="_cc" value="another@email.com,yetanother@email.com" />'></p>
+            </div>
+      </div>
+
+      <div class="container narrow block">
+            <div class="col-1-1">
+                <h4><span class="code">_bcc</span></h4>
+                <p>This value is used for the email's BCC Field. This lets you send a copy of each submission to another email address.</p>
+                <p><input type="text" class="code" value='<input type="hidden" name="_bcc" value="another@email.com" />'></p>
+				<p>If you want to BCC multiple email addresses, then just make it a list of email addresses separate by commas.</p>
+                <p><input type="text" class="code" value='<input type="hidden" name="_bcc" value="another@email.com,yetanother@email.com" />'></p>
             </div>
       </div>
 

--- a/formspree/utils.py
+++ b/formspree/utils.py
@@ -130,13 +130,6 @@ def send_email(to=None, subject=None, text=None, html=None, sender=None, cc=None
 				valid_emails.append(email)
 		data.update({'cc': valid_emails})
 
-	if bcc:
-		valid_emails = []
-		for email in bcc:
-			if IS_VALID_EMAIL(email):
-				valid_emails.append(email)
-		data.update({'bcc': valid_emails})
-
     log.info('Queuing message to %s' % str(to))
 
     result = requests.post(

--- a/formspree/utils.py
+++ b/formspree/utils.py
@@ -123,14 +123,14 @@ def send_email(to=None, subject=None, text=None, html=None, sender=None, cc=None
     if reply_to and IS_VALID_EMAIL(reply_to):
         data.update({'replyto': reply_to})
 
-    if cc:
+	if cc:
 		valid_emails = []
 		for email in cc:
 			if IS_VALID_EMAIL(email):
 				valid_emails.append(email)
 		data.update({'cc': valid_emails})
 
-    if bcc:
+	if bcc:
 		valid_emails = []
 		for email in bcc:
 			if IS_VALID_EMAIL(email):

--- a/formspree/utils.py
+++ b/formspree/utils.py
@@ -130,6 +130,13 @@ def send_email(to=None, subject=None, text=None, html=None, sender=None, cc=None
 				valid_emails.append(email)
 		data.update({'cc': valid_emails})
 
+    if bcc:
+		valid_emails = []
+		for email in bcc:
+			if IS_VALID_EMAIL(email):
+				valid_emails.append(email)
+		data.update({'bcc': valid_emails})
+
     log.info('Queuing message to %s' % str(to))
 
     result = requests.post(

--- a/formspree/utils.py
+++ b/formspree/utils.py
@@ -123,8 +123,12 @@ def send_email(to=None, subject=None, text=None, html=None, sender=None, cc=None
     if reply_to and IS_VALID_EMAIL(reply_to):
         data.update({'replyto': reply_to})
 
-    if cc and IS_VALID_EMAIL(cc):
-        data.update({'cc': cc})
+    if cc:
+		valid_emails = []
+		for email in cc:
+			if IS_VALID_EMAIL(email):
+				valid_emails.append(email)
+		data.update({'cc': valid_emails})
 
     log.info('Queuing message to %s' % str(to))
 


### PR DESCRIPTION
**New feature**

**Changes proposed in this pull request:**

* Allow for a user to include multiple _cc email addresses by allowing for a list of emails separate by comma
* Also allow for same functionality with BCC

**Have you made sure to add:**
- [ ] Tests
- [X] Documentation

No tests for _cc exist currently, but maybe some should be added. It is just a standard feature in the SendGrid API though.

**Deploy notes**

None necessary

**Any Additional Information**

Not sure if adding the BCC field is too many options, but it might be nice if people want to receive a copy of submissions.