### PR TITLE
Password reset with email.

### DIFF
--- a/formspree/routes.py
+++ b/formspree/routes.py
@@ -21,6 +21,8 @@ def configure_routes(app):
     app.add_url_rule('/account/confirm/<digest>', 'confirm-account-email', view_func=users.views.confirm_email, methods=['GET'])
     app.add_url_rule('/register', 'register', view_func=users.views.register, methods=['GET', 'POST'])
     app.add_url_rule('/login', 'login', view_func=users.views.login, methods=   ['GET', 'POST'])
+    app.add_url_rule('/login/reset', 'forgot-password', view_func=users.views.forgot_password, methods=['GET', 'POST'])
+    app.add_url_rule('/login/reset/<digest>', 'reset-password', view_func=users.views.reset_password, methods=['GET', 'POST'])
     app.add_url_rule('/logout', 'logout', view_func=users.views.logout, methods=['GET'])
 
     # Users' forms

--- a/formspree/templates/email/pre_inline_style/email_styles.css
+++ b/formspree/templates/email/pre_inline_style/email_styles.css
@@ -32,11 +32,11 @@ table td {
     BODY & CONTAINER
 ------------------------------------- */
 body {
-  background-color: #f6f6f6;
+  background-color: #FFF;
 }
 
 .body-wrap {
-  background-color: #f6f6f6;
+  background-color: #FFF;
   width: 100%;
 }
 
@@ -60,7 +60,7 @@ body {
 ------------------------------------- */
 .main {
   background-color: #fff;
-  border: 1px solid #e9e9e9;
+/*  border: 1px solid #e9e9e9;*/
   border-radius: 3px;
 }
 
@@ -93,7 +93,7 @@ body {
 ------------------------------------- */
 h1, h2, h3 {
   font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-  color: #000;
+  color: #1b3544;
   margin: 40px 0 0;
   line-height: 1.2em;
   font-weight: 400;
@@ -183,6 +183,25 @@ a {
 .clear {
   clear: both;
 }
+/* -------------------------------------
+    HEADER
+    Display Formspree logo and wordmark
+------------------------------------- */
+.header {
+	font-size: 16px;
+	color: #1b3544;
+	font-weight: 500;
+	padding: 20px;
+	border-bottom: 1px solid;
+	text-align: center;
+/*	border-style: solid;*/
+	border-color: #359173;
+}
+
+.logo {
+	max-width: 70px;
+}
+
 
 /* -------------------------------------
     ALERTS
@@ -190,11 +209,11 @@ a {
 ------------------------------------- */
 .alert {
   font-size: 16px;
-  color: #fff;
+  color: #ffffff;
   font-weight: 500;
   padding: 20px;
   text-align: center;
-  border-radius: 3px 3px 0 0;
+/*  border-radius: 3px 3px 0 0;*/
 }
 .alert.straight-edge {
 	border-radius: 0;

--- a/formspree/templates/email/pre_inline_style/reset-password.html
+++ b/formspree/templates/email/pre_inline_style/reset-password.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+	<meta name="viewport" content="width=device-width" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<title>Reset Password</title>
+	<link href="email_styles.css" media="all" rel="stylesheet" type="text/css" />
+</head>
+
+<body itemscope itemtype="http://schema.org/EmailMessage">
+
+	<table class="body-wrap">
+		<tr>
+			<td></td>
+			<tr>
+				<td class="header">
+					<img src="{{config.SERVICE_URL}}/static/img/logo.png">
+					<br /> Reset {{config.SERVICE_NAME}} Password
+				</td>
+			</tr>
+			<td class="container" width="600">
+				<div class="content">
+					<table class="main" width="100%" cellpadding="0" cellspacing="0">
+						<tr>
+							<td class="content-wrap">
+								<table width="100%" cellpadding="0" cellspacing="0">
+									<tr>
+										<td class="content-block">
+											Hey there,
+										</td>
+									</tr>
+									<tr>
+										<td class="content-block">
+											You told us you forgot your password. If you really did, click here to choose a new one:
+										</td>
+									</tr>
+									<tr>
+										<td class="content-block">
+											<a href="{{ link }}" class="btn-primary">Choose a new password</a>
+										</td>
+									</tr>
+									<tr>
+										<td class="content-block">
+											If you didn't mean to reset your password, then you can just ignore this email; your password will not change.
+										</td>
+									</tr>
+								</table>
+							</td>
+						</tr>
+					</table>
+					<div class="footer">
+						<table width="100%">
+							<tr>
+								<td class="aligncenter content-block">Why did I receive this?
+								<br>Someone (hopefully you?) used reset your password on {{config.SERVICE_NAME}}. If this wasn't you, you don't need to do anything, your password will stay the same.</td>
+							</tr>
+							<tr>
+								<td class="aligncenter content-block">
+									<a href="//facebook.com/formspree"><img src="{{config.SERVICE_URL}}/static/img/social/fb.png"></a>
+									<a href="//twitter.com/formspree"><img src="{{config.SERVICE_URL}}/static/img/social/twitter.png"</a>
+									<a href="//github.com/formspree/formspree"><img src="{{config.SERVICE_URL}}/static/img/social/github.png"</a>
+								</td>
+							</tr>
+						</table>
+					</div>
+				</div>
+			</td>
+			<td></td>
+		</tr>
+	</table>
+
+</body>
+
+</html>

--- a/formspree/templates/email/reset-password.html
+++ b/formspree/templates/email/reset-password.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+  <head>
+	<meta name="viewport" content="width=device-width" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<title>Reset Password</title>
+</head>
+  <body itemscope="" itemtype="http://schema.org/EmailMessage" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #FFF; margin: 0; padding: 0;" bgcolor="#FFF">
+
+	<table class="body-wrap" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; background-color: #FFF; margin: 0;" bgcolor="#FFF">
+		<tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+			<td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0;" valign="top"></td>
+			</tr><tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+				<td class="header" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; vertical-align: top; width: 100%; color: #1b3544; font-weight: 500; border-bottom-style: solid; border-bottom-width: 1px; text-align: center; margin: 0 0 20px; padding: 20px; border: #359173;" align="center" valign="top">
+					<img src="{{config.SERVICE_URL}}/static/img/logo.png" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; max-width: 100%; margin: 0;" />
+					<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" /> Reset {{config.SERVICE_NAME}} Password
+				</td>
+			</tr>
+			<td class="container" width="600" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; display: block !important; max-width: 600px !important; clear: both !important; width: 100% !important; margin: 0 auto; padding: 0;" valign="top">
+				<div class="content" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; max-width: 600px; display: block; margin: 0 auto; padding: 0;">
+					<table class="main" width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; border-radius: 3px; background-color: #fff; margin: 0;" bgcolor="#fff">
+						<tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+							<td class="content-wrap" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 10px;" valign="top">
+								<table width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+									<tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+										<td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+											Hey there,
+										</td>
+									</tr>
+									<tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+										<td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+											You told us you forgot your password. If you really did, click here to choose a new one:
+										</td>
+									</tr>
+									<tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+										<td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+											<a href="{{ link }}" class="btn-primary" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #348eda; margin: 0; border-color: #348eda; border-style: solid; border-width: 10px 20px;">Choose a new password</a>
+										</td>
+									</tr>
+									<tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+										<td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+											If you didn't mean to reset your password, then you can just ignore this email; your password will not change.
+										</td>
+									</tr>
+								</table>
+							</td>
+						</tr>
+					</table>
+					<div class="footer" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; clear: both; color: #999; margin: 0; padding: 20px;">
+						<table width="100%" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+							<tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+								<td class="aligncenter content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 12px; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top">Why did I receive this?
+								<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />Someone (hopefully you?) used reset your password on {{config.SERVICE_NAME}}. If this wasn't you, you don't need to do anything, your password will stay the same.</td>
+							</tr>
+							<tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+								<td class="aligncenter content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 12px; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top">
+									<a href="//facebook.com/formspree" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;"><img src="{{config.SERVICE_URL}}/static/img/social/fb.png" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; max-width: 100%; margin: 0;" /></a>
+									<a href="//twitter.com/formspree" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;"><img src="{{config.SERVICE_URL}}/static/img/social/twitter.png" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; max-width: 100%; margin: 0;" />
+									</a><a href="//github.com/formspree/formspree" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;"><img src="{{config.SERVICE_URL}}/static/img/social/github.png" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; max-width: 100%; margin: 0;" />
+								</a></td>
+							</tr>
+						</table>
+					</div>
+				</div>
+			</td>
+			<td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0;" valign="top"></td>
+
+	</table>
+
+
+
+</body>
+</html>

--- a/formspree/templates/email/reset-password.txt
+++ b/formspree/templates/email/reset-password.txt
@@ -1,0 +1,7 @@
+If you are {{ addr }} and you've requested a password change from {{ config.SERVICE_NAME }}, then open the following link: 
+
+Link: {{ link }}
+
+You'll be prompted to choose a new password.
+
+If you don't want to reset your password or you don't know what is this all about, just ignore this email.

--- a/formspree/templates/email/text_form.html
+++ b/formspree/templates/email/text_form.html
@@ -1,0 +1,24 @@
+<p>Hey there,</p>
+
+</p>Someone just submitted your form on {{host}}.</p>
+
+<p>Here's what they had to say:</p>
+
+<hr style="color: #359173; border: 1px dashed #359173;">
+
+<table border="0" width="100%">
+    {% for k in keys %}
+        <tr>
+            <td align="right" valign="top" width="70" style="padding: 5px 5px 5px 0;"><strong>{{k}}:</strong> </td>
+            <td align="left" valign="top" width="*" style="padding: 5px 5px 5px;">
+              <pre style="margin: 0; font-family: inherit;">{{data.get(k,'')}}</pre>
+            </td>
+        </tr>
+    {% endfor %}
+</table>
+
+<small style="margin-left: 10px; font-size: 10px;">This form was submitted at {{ now }}.</small>
+
+<hr style="color: #359173; border: 1px dashed #359173;" />
+
+<p>You are receiving this because you confirmed this email address on <a href="{{config.SERVICE_URL}}">{{config.SERVICE_NAME}}</a>. If you don't remember doing that, or no longer wish to receive these emails, please remove the form on {{host}} or send an email to {{config.CONTACT_EMAIL}}.</p>

--- a/formspree/templates/layouts/base.html
+++ b/formspree/templates/layouts/base.html
@@ -21,7 +21,7 @@
             <div class="col-1-1">
             {% for category, message in messages %}
               <div class="alert-box {{ category }} banner">
-               {{ message }}
+               {{ message|safe }}
               </div>
             {% endfor %}
            </div>

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -160,6 +160,14 @@
 
       <div class="container narrow block">
             <div class="col-1-1">
+                <h4><span class="code">_format</span></h4>
+                <p>Add this to your form will allow for you to receive plain text versions of emails for form submissions.</p>
+                <p><input type="text" class="code" value='<input type="text" name="_format" value="text" style="display:none" />'></p>
+            </div>
+      </div>
+
+      <div class="container narrow block">
+            <div class="col-1-1">
                 <h4>Using AJAX</h4>
                 <p>You can use {{config.SERVICE_NAME}} via AJAX. This even works cross-origin. The trick is to set the <span class="code">Accept</span> header to <span class="code">application/json</span>. If you're using jQuery this can be done like so:
                 <p class="card code">

--- a/formspree/templates/users/forgot.html
+++ b/formspree/templates/users/forgot.html
@@ -1,0 +1,19 @@
+{% extends 'layouts/base.html' %}
+
+{% block bodyclass %}dashboard login{% endblock%}
+{% block bodyid %}{% endblock%}
+
+{% block base %}
+  <div class="row">
+    <div class="container narrow card">
+      {% block form %}
+        <form action="{{ url_for('forgot-password', next=request.args.get('next')) }}" method=post>
+          <h2>Enter your registered email</h2>
+          <input type="email" name="email" placeholder="me@email.com" required>
+          <button type="submit">Done</button>
+        </form>
+      {% endblock %}
+    </div>
+  </div>
+
+{% endblock base %}

--- a/formspree/templates/users/login.html
+++ b/formspree/templates/users/login.html
@@ -9,12 +9,13 @@
       {% block form %}
         <form action="" method=post>
           <h2>Log in to {{ config.SERVICE_NAME }}</h2>
-          <input type="text" id="email" name="email" placeholder="Enter Email" required>
+          <input type="email" id="email" name="email" placeholder="Enter Email" required>
           <input type="password" id="password" name="password" placeholder="Enter Password" required>
           <button type="submit">Sign in</button>
         </form>
 
         <p>Don't have an account? <a href="{{ url_for('register', next=request.args.get('next')) }}">Register</a>!</p>
+        <p>Forgot your password? <a href="{{ url_for('forgot-password', next=request.args.get('next')) }}">Reset it</a>!</p>
       {% endblock %}
     </div>
   </div>

--- a/formspree/templates/users/reset.html
+++ b/formspree/templates/users/reset.html
@@ -1,0 +1,20 @@
+{% extends 'layouts/base.html' %}
+
+{% block bodyclass %}dashboard login{% endblock%}
+{% block bodyid %}{% endblock%}
+
+{% block base %}
+  <div class="row">
+    <div class="container narrow card">
+      {% block form %}
+        <form action="{{ url_for('reset-password', digest=digest, next=request.args.get('next')) }}" method=post>
+          <h2>Set a new password for {{ current_user.email }}</h2>
+          <input type="password" name="password1" placeholder="Enter Password" required>
+          <input type="password" name="password2" placeholder="Enter it again, to make sure you'll not forget" required>
+          <button type="submit">Done</button>
+        </form>
+      {% endblock %}
+    </div>
+  </div>
+
+{% endblock base %}

--- a/formspree/users/models.py
+++ b/formspree/users/models.py
@@ -71,6 +71,7 @@ class User(DB.Model):
             to=self.email,
             subject='Reset your %s password!' % settings.SERVICE_NAME,
             text=render_template('email/reset-password.txt', addr=self.email, link=link),
+            html=render_template('email/reset-password.html', add=self.email, link=link),
             sender=settings.ACCOUNT_SENDER
         )
         if not res[0]:


### PR DESCRIPTION
**Adds a missing basic feature we should have always had.**

**Changes proposed in this pull request:**

* Adds a link to the `/login` screen for users who forgot their passwords.
* Generates an HMAC token and sends for the user based on the email he has inputted.
* The token is valid eternally as long as the password doesn't change. If the token is never clicked, never happens. Even if it is clicked, but the user gives up completing the password change process, never happens, the old password is still valid.

**Have you made sure to add:**
- [x] Tests
- [ ] Documentation

**Screenshots and GIFs**

I'll have a working demo soon, but there are two new screens, one just for inputting the email for which the password will be resetted, and other for inputting the new password (twice). They are exactly the same as the `/login` and `/register` screens.

**Deploy notes**

Just deploy.