### PR TITLE
Use https in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 FORMSPREE.IO
 ------------
 
-Functional HTML forms. Hosted at [http://formspree.io](http://formspree.io).
+Functional HTML forms. Hosted at [https://formspree.io](https://formspree.io).
 
 Just send your form to our URL and we'll forward it to your email. No PHP, Javascript or sign up required — perfect for static sites!
 Example:
 
-    <form action="//formspree.io/you@email.com">
+    <form action="https://formspree.io/you@email.com">
         <input type="text" name="name">
         <input type="email" name="_replyto">
         <input type="submit" value="Send">
@@ -59,7 +59,7 @@ Add this "honeypot" field to avoid spam by fooling scrapers. If a value is provi
 You can use Formspree via AJAX. This even works cross-origin. The trick is to set the Accept header to application/json. If you're using jQuery this can be done like so:
 
     $.ajax({
-        url: "//formspree.io/you@email.com",
+        url: "https://formspree.io/you@email.com",
         method: "POST",
         data: {message: "hello!"},
         dataType: "json"

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -42,7 +42,7 @@
             <div class="col-1-1">
                 <h3>1. Setup the HTML form</h3>
                 <p>Change your form's <span class="code">action</span>-attribute to this and replace your@email.com with your own email.</p>
-                <p><input type="text" class="code" value="http:{{config.API_ROOT}}/your@email.com" /></p>
+                <p><input type="text" class="code" value="{{config.API_ROOT}}/your@email.com" /></p>
             </div>
       </div>
 
@@ -251,7 +251,7 @@
             <p>{{config.SERVICE_NAME}} is a tool <a href="https://github.com/formspree/formspree">managed on GitHub</a>. To contact us send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a> or use the form on the right.</p>
           </div>
           <div class="col-1-2">
-            <form method="POST" action="//{{config.API_ROOT}}/{{config.CONTACT_EMAIL}}">
+            <form method="POST" action="{{config.API_ROOT}}/{{config.CONTACT_EMAIL}}">
               <input type="email" name="_replyto" placeholder="Your email" />
               <textarea name="message" rows="5" placeholder="Your message (when sending support requests, please include the URL to your form if that is relevant)"></textarea>
               <input type="text" name="_gotcha" style="display:none">

--- a/formspree/templates/users/dashboard.html
+++ b/formspree/templates/users/dashboard.html
@@ -22,7 +22,7 @@
           <p>{{config.SERVICE_NAME}} is a tool <a href="https://github.com/formspree/formspree">managed on GitHub</a>. To contact us send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a> or use the form on the right.</p>
         </div>
         <div class="col-1-2">
-          <form method="POST" action="//{{config.API_ROOT}}/{{config.CONTACT_EMAIL}}">
+          <form method="POST" action="{{config.API_ROOT}}/{{config.CONTACT_EMAIL}}">
             <input type="email" name="_replyto" placeholder="Your email" />
             <textarea name="message" rows="5" placeholder="Your message"></textarea>
             <input type="text" name="_gotcha" style="display:none">


### PR DESCRIPTION
As [Paul Irish put it](https://twitter.com/paul_irish/status/588502455530311680):

> The protocol relative URL is now an anti-pattern. If the asset is available on HTTPS, always request it with that. https://www.paulirish.com/2010/the-protocol-relative-url/

This ensures that forms are always submitted using HTTPS, even on websites delivered by HTTP.

-----
**Fixes partially #85.**

**Changes proposed in this pull request:**

* Drop the use of the protocol-relative URL (`//host/...`) in favor of always using HTTPS (`https://host/...`).
* Change the home page URL to HTTPS.
* Change the `API_ROOT` config variable: now it must begin with `https://`.

**Screenshots and GIFs**

See website screenshots over at https://github.com/formspree/formspree/issues/85#issuecomment-197026612.

![icanhazhttps](http://cdn.meme.am/instances/61459771.jpg)

**Deploy notes**

The `API_ROOT` environment variable should be changed to start with `https://`. As I said before, I can make the commit so that it doesn't require changing it, i.e. by hardcoding `https://` on forms that use `config.API_ROOT`.
