### PR TITLE
Fix form creation modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 development.env
 *.py[cod]
 node_modules
-
-node_modules
+npm-debug.log
 
 # C extensions
 *.so

--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -73,8 +73,14 @@ def remove_www(host):
     return host
 
 
-def sitewide_file_exists (url, email):
-    url = urljoin(url, '/' + 'formspree_verify_{0}.txt'.format(email))
+def sitewide_file_check(url, email):
+    url = urljoin(url, '/formspree-verify.txt')
     log.debug('Checking sitewide file: %s' % url)
     res = requests.get(url, timeout=2)
-    return res.ok
+    if not res.ok: return False
+
+    for line in res.text.splitlines():
+        if line.strip() == email:
+            return True
+
+    return False

--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -283,10 +283,6 @@ class Form(DB.Model):
             return form
 
     @property
-    def action(self):
-        return url_for('send', email_or_string=self.hashid, _external=True)
-
-    @property
     def hashid(self):
         # A unique identifier for the form that maps to its id,
         # but doesn't seem like a sequential integer
@@ -297,10 +293,6 @@ class Form(DB.Model):
                 raise Exception("this form doesn't have an id yet, commit it first.")
             self._hashid = HASHIDS_CODEC.encode(self.id)
         return self._hashid
-
-    @property
-    def is_new(self):
-        return not self.host
 
 from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.ext.mutable import MutableDict

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -358,7 +358,7 @@ def create_form():
         })
     else:
         flash('Your new form endpoint was created!', 'success')
-        return redirect(url_for('dashboard') + '#form-' + form.hashid)
+        return redirect(url_for('dashboard', new=form.hashid) + '#form-' + form.hashid)
 
 @login_required
 def sitewide_check():

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -16,7 +16,7 @@ from helpers import ordered_storage, referrer_to_path, referrer_to_baseurl, HASH
 from formspree import settings, log
 from formspree.app import DB
 from formspree.utils import request_wants_json, jsonerror, IS_VALID_EMAIL
-from helpers import ordered_storage, referrer_to_path, remove_www, sitewide_file_exists, HASH, EXCLUDE_KEYS
+from helpers import ordered_storage, referrer_to_path, remove_www, sitewide_file_check, HASH, EXCLUDE_KEYS
 from models import Form, Submission
 
 def thanks():
@@ -323,7 +323,7 @@ def create_form():
 
         # sitewide forms, verified with a file at the root of the target domain
         if sitewide:
-            if sitewide_file_exists(url, email):
+            if sitewide_file_check(url, email):
                 form.host = remove_www(referrer_to_path(urljoin(url, '/'))[:-1])
                 form.sitewide = True
             else:
@@ -362,7 +362,7 @@ def sitewide_check():
     email = request.args.get('email')
     url = request.args.get('url')
 
-    if sitewide_file_exists(url, email):
+    if sitewide_file_check(url, email):
         return '', 200
     else:
         return '', 404

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -441,8 +441,7 @@ def form_submissions(hashid, format=None):
             )
 
 @login_required
-def form_toggle():
-    hashid = request.form.get('hashid')
+def form_toggle(hashid):
     form = Form.get_with_hashid(hashid)
 
     # check that this request came from user dashboard to prevent XSS and CSRF
@@ -473,8 +472,7 @@ def form_toggle():
         return redirect(url_for('dashboard'))
 
 @login_required
-def form_deletion():
-    hashid = request.form.get('hashid')
+def form_deletion(hashid):
     form = Form.get_with_hashid(hashid)
 
     # check that this request came from user dashboard to prevent XSS and CSRF
@@ -503,8 +501,7 @@ def form_deletion():
         return redirect(url_for('dashboard'))
 
 @login_required
-def submission_deletion(hashid):
-    submissionid = request.form.get('submissionid')
+def submission_deletion(hashid, submissionid):
     submission = Submission.query.get(submissionid)
     form = Form.get_with_hashid(hashid)
 

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -291,7 +291,10 @@ def forms():
             } for f in forms]
         })
     else:
-        return render_template('forms/list.html', forms=forms)
+        return render_template('forms/list.html',
+            enabled_forms=[form for form in forms if not form.disabled],
+            disabled_forms=[form for form in forms if form.disabled]
+        )
 
 
 @login_required
@@ -355,7 +358,7 @@ def create_form():
         })
     else:
         flash('Your new form endpoint was created!', 'success')
-        return redirect(url_for('dashboard') + '#view-code-' + form.hashid)
+        return redirect(url_for('dashboard') + '#form-' + form.hashid)
 
 @login_required
 def sitewide_check():

--- a/formspree/routes.py
+++ b/formspree/routes.py
@@ -32,9 +32,9 @@ def configure_routes(app):
     app.add_url_rule('/forms/sitewide-check', view_func=forms.views.sitewide_check, methods=['GET'])
     app.add_url_rule('/forms/<hashid>/', 'form-submissions', view_func=forms.views.form_submissions, methods=['GET'])
     app.add_url_rule('/forms/<hashid>.<format>', 'form-submissions', view_func=forms.views.form_submissions, methods=['GET'])
-    app.add_url_rule('/forms/toggle', 'form-toggle', view_func = forms.views.form_toggle, methods=['POST'])
-    app.add_url_rule('/forms/delete', 'form-deletion', view_func=forms.views.form_deletion, methods=['POST'])
-    app.add_url_rule('/forms/<hashid>/delete', 'submission-deletion', view_func=forms.views.submission_deletion, methods=['POST'])
+    app.add_url_rule('/forms/<hashid>/toggle', 'form-toggle', view_func=forms.views.form_toggle, methods=['POST'])
+    app.add_url_rule('/forms/<hashid>/delete', 'form-deletion', view_func=forms.views.form_deletion, methods=['POST'])
+    app.add_url_rule('/forms/<hashid>/delete/<submissionid>', 'submission-deletion', view_func=forms.views.submission_deletion, methods=['POST'])
 
     # Webhooks
     app.add_url_rule('/webhooks/stripe', view_func=users.views.stripe_webhook, methods=['POST'])

--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -1,4 +1,4 @@
-@import 'https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css';
+@import "https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css";
 article,
 aside,
 details,
@@ -343,7 +343,8 @@ a {
 .caps {
   text-transform: uppercase; }
 
-/*-------------------------------------*	HINT.css - A CSS tooltip library
+/*-------------------------------------*\
+	HINT.css - A CSS tooltip library
 \*-------------------------------------*/
 /**
  * HINT.css is a tooltip library made in pure CSS.
@@ -369,11 +370,11 @@ a {
   position: relative;
   display: inline-block;
   /**
-	 * tooltip arrow
-	 */
+   * tooltip arrow
+   */
   /**
-	 * tooltip body
-	 */ }
+   * tooltip body
+   */ }
   .hint:before, .hint:after, [data-hint]:before, [data-hint]:after {
     position: absolute;
     -webkit-transform: translate3d(0, 0, 0);
@@ -437,14 +438,11 @@ a {
  */
 .hint--top:before {
   margin-bottom: -12px; }
-
 .hint--top:after {
   margin-left: -18px; }
-
 .hint--top:before, .hint--top:after {
   bottom: 100%;
   left: 18px; }
-
 .hint--top:hover:after, .hint--top:hover:before, .hint--top:focus:after, .hint--top:focus:before {
   -webkit-transform: translateY(-8px);
   -moz-transform: translateY(-8px);
@@ -455,14 +453,11 @@ a {
  */
 .hint--bottom:before {
   margin-top: -12px; }
-
 .hint--bottom:after {
   margin-left: -18px; }
-
 .hint--bottom:before, .hint--bottom:after {
   top: 100%;
   left: 18px; }
-
 .hint--bottom:hover:after, .hint--bottom:hover:before, .hint--bottom:focus:after, .hint--bottom:focus:before {
   -webkit-transform: translateY(8px);
   -moz-transform: translateY(8px);
@@ -474,14 +469,11 @@ a {
 .hint--right:before {
   margin-left: -12px;
   margin-bottom: -6px; }
-
 .hint--right:after {
   margin-bottom: -20px; }
-
 .hint--right:before, .hint--right:after {
   left: 100%;
   bottom: 50%; }
-
 .hint--right:hover:after, .hint--right:hover:before, .hint--right:focus:after, .hint--right:focus:before {
   -webkit-transform: translateX(8px);
   -moz-transform: translateX(8px);
@@ -493,14 +485,11 @@ a {
 .hint--left:before {
   margin-right: -12px;
   margin-bottom: -6px; }
-
 .hint--left:after {
   margin-bottom: -20px; }
-
 .hint--left:before, .hint--left:after {
   right: 100%;
   bottom: 50%; }
-
 .hint--left:hover:after, .hint--left:hover:before, .hint--left:focus:after, .hint--left:focus:before {
   -webkit-transform: translateX(-8px);
   -moz-transform: translateX(-8px);
@@ -523,16 +512,12 @@ a {
  */
 .hint--error:after {
   background-color: #b34e4d; }
-
 .hint--error.hint--top:before {
   border-top-color: #b34e4d; }
-
 .hint--error.hint--bottom:before {
   border-bottom-color: #b34e4d; }
-
 .hint--error.hint--left:before {
   border-left-color: #b34e4d; }
-
 .hint--error.hint--right:before {
   border-right-color: #b34e4d; }
 
@@ -541,16 +526,12 @@ a {
  */
 .hint--warning:after {
   background-color: #c09854; }
-
 .hint--warning.hint--top:before {
   border-top-color: #c09854; }
-
 .hint--warning.hint--bottom:before {
   border-bottom-color: #c09854; }
-
 .hint--warning.hint--left:before {
   border-left-color: #c09854; }
-
 .hint--warning.hint--right:before {
   border-right-color: #c09854; }
 
@@ -559,16 +540,12 @@ a {
  */
 .hint--info:after {
   background-color: #3986ac; }
-
 .hint--info.hint--top:before {
   border-top-color: #3986ac; }
-
 .hint--info.hint--bottom:before {
   border-bottom-color: #3986ac; }
-
 .hint--info.hint--left:before {
   border-left-color: #3986ac; }
-
 .hint--info.hint--right:before {
   border-right-color: #3986ac; }
 
@@ -577,16 +554,12 @@ a {
  */
 .hint--success:after {
   background-color: #458746; }
-
 .hint--success.hint--top:before {
   border-top-color: #458746; }
-
 .hint--success.hint--bottom:before {
   border-bottom-color: #458746; }
-
 .hint--success.hint--left:before {
   border-left-color: #458746; }
-
 .hint--success.hint--right:before {
   border-right-color: #458746; }
 
@@ -602,22 +575,18 @@ a {
 .hint--always:after, .hint--always:before {
   opacity: 1;
   visibility: visible; }
-
 .hint--always.hint--top:after, .hint--always.hint--top:before {
   -webkit-transform: translateY(-8px);
   -moz-transform: translateY(-8px);
   transform: translateY(-8px); }
-
 .hint--always.hint--bottom:after, .hint--always.hint--bottom:before {
   -webkit-transform: translateY(8px);
   -moz-transform: translateY(8px);
   transform: translateY(8px); }
-
 .hint--always.hint--left:after, .hint--always.hint--left:before {
   -webkit-transform: translateX(-8px);
   -moz-transform: translateX(-8px);
   transform: translateX(-8px); }
-
 .hint--always.hint--right:after, .hint--always.hint--right:before {
   -webkit-transform: translateX(8px);
   -moz-transform: translateX(8px);
@@ -658,9 +627,9 @@ a {
   background-color: transparent;
   color: #359173; }
   .alert-box.error {
-    border-color: #ff1708;
+    border-color: #D9534F;
     background-color: transparent;
-    color: #ff1708; }
+    color: #D9534F; }
   .alert-box.success {
     border-color: #359173;
     background-color: transparent;
@@ -684,8 +653,8 @@ a.alert-box:hover {
   border-color: #f1f1fa; }
 
 a.alert-box.error:hover {
-  color: #ff1708;
-  border-color: #ff1708; }
+  color: #D9534F;
+  border-color: #D9534F; }
 
 a.alert-box.success:hover {
   color: #359173;
@@ -702,7 +671,6 @@ a.alert-box.success:hover {
 
 .login .row {
   padding: 2.2em 0; }
-
 .login input, .login button {
   font-size: 1.2em;
   margin: 2px 0 1em 0; }
@@ -728,8 +696,8 @@ a.alert-box.success:hover {
     text-align: center;
     width: 32px; }
   .dashboard .delete {
-    color: #ff1708;
-    border-color: #ff1708; }
+    color: #D9534F;
+    border-color: #D9534F; }
   .dashboard .delete:hover {
     transition: color 0.3s ease-in-out;
     color: #D87431; }
@@ -756,15 +724,13 @@ a.alert-box.success:hover {
     .dashboard table.forms td.n-submissions, .dashboard table.emails td.n-submissions {
       min-width: 150px; }
     .dashboard table.forms tr.new span[class^="ion-"], .dashboard table.emails tr.new span[class^="ion-"] {
-      color: #ff1708; }
+      color: #D9534F; }
     .dashboard table.forms tr.waiting_confirmation span[class^="ion-"], .dashboard table.emails tr.waiting_confirmation span[class^="ion-"] {
       color: #D87431; }
     .dashboard table.forms tr.verified span[class^="ion-"], .dashboard table.emails tr.verified span[class^="ion-"] {
       color: #2A735B; }
     .dashboard table.forms tr.new a:not(*:hover), .dashboard table.emails tr.new a:not(*:hover) {
-      display: block;
       border-bottom: 1px dotted;
-      float: left;
       margin-bottom: -1px;
       line-height: 1em; }
     .dashboard table.forms tr.new .never, .dashboard table.emails tr.new .never {
@@ -823,8 +789,7 @@ a.alert-box.success:hover {
       padding: 0;
       margin-top: 13px;
       float: left; }
-  .dashboard .modal:not(.js):target > *,
-  .dashboard .modal.target > * {
+  .dashboard .modal:not(.js):target > *, .dashboard .modal.target > * {
     -webkit-transform: translate(0, 0);
     -ms-transform: translate(0, 0);
     transform: translate(0, 0);
@@ -842,14 +807,11 @@ a.alert-box.success:hover {
   .dashboard .modal:not(.js):target:before, .dashboard .modal.target:before {
     display: block; }
   .dashboard .modal .red {
-    color: #ff1708; }
+    color: #D9534F; }
   .dashboard .fa-unlock:hover::before {
     content: "\f023"; }
   .dashboard .fa-lock:hover::before {
     content: "\f09c"; }
-  .dashboard .fa-trash-o:hover::before,
-  .dashboard .fa-trash:hover::before {
-    content: "\f071"; }
 
 .html-highlight {
   clear: both;
@@ -1032,9 +994,9 @@ body > nav {
 @media screen and (max-width: 40em) {
   body > nav.js {
     display: none; }
+
   .slicknav_menu {
     display: block; } }
-
 .slicknav_menu {
   background: #4CD1A7;
   /* our transcluded menu header ("Welcome...") */ }
@@ -1227,23 +1189,22 @@ button.toast-close-button {
   #toast-container > div {
     padding: 8px 8px 8px 50px;
     width: 11em; }
+
   #toast-container .toast-close-button {
     right: -0.2em;
     top: -0.2em; } }
-
 @media all and (min-width: 241px) and (max-width: 480px) {
   #toast-container > div {
     padding: 8px 8px 8px 50px;
     width: 18em; }
+
   #toast-container .toast-close-button {
     right: -0.2em;
     top: -0.2em; } }
-
 @media all and (min-width: 481px) and (max-width: 768px) {
   #toast-container > div {
     padding: 15px 15px 15px 50px;
     width: 25em; } }
-
 html {
   height: 100%; }
 
@@ -1287,7 +1248,7 @@ body#card {
   #header .success i {
     color: #359173; }
   #header .error i {
-    color: #ff1708; }
+    color: #D9534F; }
   #header .done {
     opacity: 0.3; }
     #header .done p {
@@ -1413,7 +1374,6 @@ button, a.button {
     -webkit-transform: translate3d(0, 0, 0);
     -moz-transform: translate3d(0, 0, 0);
     opacity: 1; } }
-
 @-webkit-keyframes dropIn {
   0% {
     opacity: 0;
@@ -1423,7 +1383,6 @@ button, a.button {
     opacity: 1;
     -webkit-transform: translate3d(0, 0, 0);
     -moz-transform: translate3d(0, 0, 0); } }
-
 @-webkit-keyframes dropInLong {
   0% {
     opacity: 0;
@@ -1433,17 +1392,14 @@ button, a.button {
     opacity: 1;
     -webkit-transform: translate3d(0, 0, 0);
     -moz-transform: translate3d(0, 0, 0); } }
-
 @-webkit-keyframes rotate {
   100% {
     -webkit-transform: rotate(45deg);
     -moz-transform: rotate(45deg); } }
-
 @-webkit-keyframes rotateBack {
   100% {
     -webkit-transform: rotate(0deg);
     -moz-transform: rotate(0deg); } }
-
 .overlay {
   position: fixed;
   width: 100%;
@@ -1491,3 +1447,5 @@ body.showOverlay .toggleOverlay {
   right: 30%;
   left: 30%;
   width: 40%; }
+
+/*# sourceMappingURL=main.css.map */

--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -709,12 +709,19 @@ a.alert-box.success:hover {
     .dashboard table.submissions pre {
       font-family: inherit;
       margin: 0; }
+  .dashboard table.forms tr, .dashboard table.emails tr {
+    height: 39px; }
+  .dashboard table.forms td.target-email, .dashboard table.emails td.target-email {
+    max-width: 250px;
+    word-break: break-word; }
+  .dashboard table.forms td.n-submissions, .dashboard table.emails td.n-submissions {
+    min-width: 150px; }
   .dashboard table.forms tr.verified span[class^="ion-"], .dashboard table.emails tr.verified span[class^="ion-"] {
     color: #2A735B; }
-  .dashboard table.forms tr.new span[class^="ion-"], .dashboard table.emails tr.new span[class^="ion-"] {
-    color: #ff1708; }
   .dashboard table.forms tr.waiting_confirmation span[class^="ion-"], .dashboard table.emails tr.waiting_confirmation span[class^="ion-"] {
     color: #D87431; }
+  .dashboard table.forms tr.new span[class^="ion-"], .dashboard table.emails tr.new span[class^="ion-"] {
+    color: #ff1708; }
   .dashboard table.forms tr.new a:not(*:hover), .dashboard table.emails tr.new a:not(*:hover) {
     color: inherit;
     display: block;
@@ -722,6 +729,8 @@ a.alert-box.success:hover {
     float: left;
     margin-bottom: -1px;
     line-height: 1em; }
+  .dashboard table.forms tr.new .never, .dashboard table.emails tr.new .never {
+    font-size: 15px; }
   .dashboard table.emails tr:nth-child(2) td {
     padding-top: 10px; }
   .dashboard table.emails td:last-child {
@@ -743,7 +752,7 @@ a.alert-box.success:hover {
   .dashboard .create-form .modal:not(.js):target > *,
   .dashboard .create-form .modal.target > * {
     top: 20%; }
-.dashboard .modal[id^="view-code"] textarea {
+.dashboard .modal[id^="form-"] textarea {
   font-size: 15px; }
 .dashboard .modal > * {
   background: #fefefe;
@@ -770,9 +779,8 @@ a.alert-box.success:hover {
   .dashboard .modal > * h4 {
     margin: 0;
     padding: 0;
-    margin-top: 13px; }
-  .dashboard .modal > * textarea {
-    min-height: 149px; }
+    margin-top: 13px;
+    float: left; }
 .dashboard .modal:not(.js):target > *, .dashboard .modal.target > * {
   -webkit-transform: translate(0, 0);
   -ms-transform: translate(0, 0);
@@ -790,9 +798,10 @@ a.alert-box.success:hover {
   z-index: 10; }
 .dashboard .modal:not(.js):target:before, .dashboard .modal.target:before {
   display: block; }
-
-.red {
-  color: #000; }
+.dashboard .modal .small {
+  text-size: 80%; }
+.dashboard .modal .red {
+  color: #ff1708; }
 
 .slicknav_btn {
   position: relative;

--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -803,6 +803,27 @@ a.alert-box.success:hover {
 .dashboard .modal .red {
   color: #ff1708; }
 
+.html-highlight {
+  clear: both;
+  font-size: 14px;
+  font-family: monospace;
+  padding: 5px;
+  border: 2px dashed #696969;
+  border-radius: 5px; }
+  .html-highlight .bracket {
+    color: #a65700; }
+  .html-highlight .tagname {
+    color: #800000;
+    font-weight: bold; }
+  .html-highlight .attrkey {
+    color: #074726; }
+  .html-highlight .equal {
+    color: #808030; }
+  .html-highlight .attrvalue {
+    color: #0000e6; }
+  .html-highlight .comment {
+    color: #696969; }
+
 .slicknav_btn {
   position: relative;
   display: block;

--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -1,4 +1,4 @@
-@import "https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css";
+@import 'https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css';
 article,
 aside,
 details,
@@ -343,8 +343,7 @@ a {
 .caps {
   text-transform: uppercase; }
 
-/*-------------------------------------*\
-	HINT.css - A CSS tooltip library
+/*-------------------------------------*	HINT.css - A CSS tooltip library
 \*-------------------------------------*/
 /**
  * HINT.css is a tooltip library made in pure CSS.
@@ -370,11 +369,11 @@ a {
   position: relative;
   display: inline-block;
   /**
-   * tooltip arrow
-   */
+	 * tooltip arrow
+	 */
   /**
-   * tooltip body
-   */ }
+	 * tooltip body
+	 */ }
   .hint:before, .hint:after, [data-hint]:before, [data-hint]:after {
     position: absolute;
     -webkit-transform: translate3d(0, 0, 0);
@@ -438,11 +437,14 @@ a {
  */
 .hint--top:before {
   margin-bottom: -12px; }
+
 .hint--top:after {
   margin-left: -18px; }
+
 .hint--top:before, .hint--top:after {
   bottom: 100%;
   left: 18px; }
+
 .hint--top:hover:after, .hint--top:hover:before, .hint--top:focus:after, .hint--top:focus:before {
   -webkit-transform: translateY(-8px);
   -moz-transform: translateY(-8px);
@@ -453,11 +455,14 @@ a {
  */
 .hint--bottom:before {
   margin-top: -12px; }
+
 .hint--bottom:after {
   margin-left: -18px; }
+
 .hint--bottom:before, .hint--bottom:after {
   top: 100%;
   left: 18px; }
+
 .hint--bottom:hover:after, .hint--bottom:hover:before, .hint--bottom:focus:after, .hint--bottom:focus:before {
   -webkit-transform: translateY(8px);
   -moz-transform: translateY(8px);
@@ -469,11 +474,14 @@ a {
 .hint--right:before {
   margin-left: -12px;
   margin-bottom: -6px; }
+
 .hint--right:after {
   margin-bottom: -20px; }
+
 .hint--right:before, .hint--right:after {
   left: 100%;
   bottom: 50%; }
+
 .hint--right:hover:after, .hint--right:hover:before, .hint--right:focus:after, .hint--right:focus:before {
   -webkit-transform: translateX(8px);
   -moz-transform: translateX(8px);
@@ -485,11 +493,14 @@ a {
 .hint--left:before {
   margin-right: -12px;
   margin-bottom: -6px; }
+
 .hint--left:after {
   margin-bottom: -20px; }
+
 .hint--left:before, .hint--left:after {
   right: 100%;
   bottom: 50%; }
+
 .hint--left:hover:after, .hint--left:hover:before, .hint--left:focus:after, .hint--left:focus:before {
   -webkit-transform: translateX(-8px);
   -moz-transform: translateX(-8px);
@@ -512,12 +523,16 @@ a {
  */
 .hint--error:after {
   background-color: #b34e4d; }
+
 .hint--error.hint--top:before {
   border-top-color: #b34e4d; }
+
 .hint--error.hint--bottom:before {
   border-bottom-color: #b34e4d; }
+
 .hint--error.hint--left:before {
   border-left-color: #b34e4d; }
+
 .hint--error.hint--right:before {
   border-right-color: #b34e4d; }
 
@@ -526,12 +541,16 @@ a {
  */
 .hint--warning:after {
   background-color: #c09854; }
+
 .hint--warning.hint--top:before {
   border-top-color: #c09854; }
+
 .hint--warning.hint--bottom:before {
   border-bottom-color: #c09854; }
+
 .hint--warning.hint--left:before {
   border-left-color: #c09854; }
+
 .hint--warning.hint--right:before {
   border-right-color: #c09854; }
 
@@ -540,12 +559,16 @@ a {
  */
 .hint--info:after {
   background-color: #3986ac; }
+
 .hint--info.hint--top:before {
   border-top-color: #3986ac; }
+
 .hint--info.hint--bottom:before {
   border-bottom-color: #3986ac; }
+
 .hint--info.hint--left:before {
   border-left-color: #3986ac; }
+
 .hint--info.hint--right:before {
   border-right-color: #3986ac; }
 
@@ -554,12 +577,16 @@ a {
  */
 .hint--success:after {
   background-color: #458746; }
+
 .hint--success.hint--top:before {
   border-top-color: #458746; }
+
 .hint--success.hint--bottom:before {
   border-bottom-color: #458746; }
+
 .hint--success.hint--left:before {
   border-left-color: #458746; }
+
 .hint--success.hint--right:before {
   border-right-color: #458746; }
 
@@ -575,18 +602,22 @@ a {
 .hint--always:after, .hint--always:before {
   opacity: 1;
   visibility: visible; }
+
 .hint--always.hint--top:after, .hint--always.hint--top:before {
   -webkit-transform: translateY(-8px);
   -moz-transform: translateY(-8px);
   transform: translateY(-8px); }
+
 .hint--always.hint--bottom:after, .hint--always.hint--bottom:before {
   -webkit-transform: translateY(8px);
   -moz-transform: translateY(8px);
   transform: translateY(8px); }
+
 .hint--always.hint--left:after, .hint--always.hint--left:before {
   -webkit-transform: translateX(-8px);
   -moz-transform: translateX(-8px);
   transform: translateX(-8px); }
+
 .hint--always.hint--right:after, .hint--always.hint--right:before {
   -webkit-transform: translateX(8px);
   -moz-transform: translateX(8px);
@@ -671,6 +702,7 @@ a.alert-box.success:hover {
 
 .login .row {
   padding: 2.2em 0; }
+
 .login input, .login button {
   font-size: 1.2em;
   margin: 2px 0 1em 0; }
@@ -678,131 +710,146 @@ a.alert-box.success:hover {
 .no-underline {
   border-bottom: none !important; }
 
-.dashboard .row:after {
-  content: "";
-  display: none; }
-.dashboard .card {
-  border-width: 0; }
-.dashboard span[class^="ion-"] {
-  display: inline-block;
-  font-size: 20px;
-  text-align: center;
-  width: 32px; }
-.dashboard .delete {
-  color: #ff1708;
-  border-color: #ff1708; }
-.dashboard .delete:hover {
-  transition: color 0.3s ease-in-out;
-  color: #D87431; }
-.dashboard table {
-  text-align: left;
-  width: 100%; }
-  .dashboard table.submissions {
-    padding: 2px;
-    background: #fff; }
-    .dashboard table.submissions th {
-      padding: 7px 0; }
-    .dashboard table.submissions tr:first-child td {
-      padding-top: 10px; }
-    .dashboard table.submissions td {
-      padding: 3px 1px; }
-    .dashboard table.submissions pre {
-      font-family: inherit;
-      margin: 0; }
-  .dashboard table.forms tr, .dashboard table.emails tr {
-    height: 39px; }
-  .dashboard table.forms td.target-email, .dashboard table.emails td.target-email {
-    max-width: 250px;
-    word-break: break-word; }
-  .dashboard table.forms td.n-submissions, .dashboard table.emails td.n-submissions {
-    min-width: 150px; }
-  .dashboard table.forms tr.new span[class^="ion-"], .dashboard table.emails tr.new span[class^="ion-"] {
-    color: #ff1708; }
-  .dashboard table.forms tr.waiting_confirmation span[class^="ion-"], .dashboard table.emails tr.waiting_confirmation span[class^="ion-"] {
+.no-border {
+  border: none !important;
+  padding: 0 !important;
+  margin: 0 !important; }
+
+.dashboard {
+  /* icon morphing */ }
+  .dashboard .row:after {
+    content: "";
+    display: none; }
+  .dashboard .card {
+    border-width: 0; }
+  .dashboard span[class^="ion-"] {
+    display: inline-block;
+    font-size: 20px;
+    text-align: center;
+    width: 32px; }
+  .dashboard .delete {
+    color: #ff1708;
+    border-color: #ff1708; }
+  .dashboard .delete:hover {
+    transition: color 0.3s ease-in-out;
     color: #D87431; }
-  .dashboard table.forms tr.verified span[class^="ion-"], .dashboard table.emails tr.verified span[class^="ion-"] {
-    color: #2A735B; }
-  .dashboard table.forms tr.new a:not(*:hover), .dashboard table.emails tr.new a:not(*:hover) {
-    display: block;
-    border-bottom: 1px dotted;
-    float: left;
-    margin-bottom: -1px;
-    line-height: 1em; }
-  .dashboard table.forms tr.new .never, .dashboard table.emails tr.new .never {
+  .dashboard table {
+    text-align: left;
+    width: 100%; }
+    .dashboard table.submissions {
+      padding: 2px;
+      background: #fff; }
+      .dashboard table.submissions th {
+        padding: 7px 0; }
+      .dashboard table.submissions tr:first-child td {
+        padding-top: 10px; }
+      .dashboard table.submissions td {
+        padding: 3px 1px; }
+      .dashboard table.submissions pre {
+        font-family: inherit;
+        margin: 0; }
+    .dashboard table.forms tr, .dashboard table.emails tr {
+      height: 39px; }
+    .dashboard table.forms td.target-email, .dashboard table.emails td.target-email {
+      max-width: 250px;
+      word-break: break-word; }
+    .dashboard table.forms td.n-submissions, .dashboard table.emails td.n-submissions {
+      min-width: 150px; }
+    .dashboard table.forms tr.new span[class^="ion-"], .dashboard table.emails tr.new span[class^="ion-"] {
+      color: #ff1708; }
+    .dashboard table.forms tr.waiting_confirmation span[class^="ion-"], .dashboard table.emails tr.waiting_confirmation span[class^="ion-"] {
+      color: #D87431; }
+    .dashboard table.forms tr.verified span[class^="ion-"], .dashboard table.emails tr.verified span[class^="ion-"] {
+      color: #2A735B; }
+    .dashboard table.forms tr.new a:not(*:hover), .dashboard table.emails tr.new a:not(*:hover) {
+      display: block;
+      border-bottom: 1px dotted;
+      float: left;
+      margin-bottom: -1px;
+      line-height: 1em; }
+    .dashboard table.forms tr.new .never, .dashboard table.emails tr.new .never {
+      font-size: 15px; }
+    .dashboard table.forms tr:not(.new) *:not(.n-submissions) a:not(*:hover), .dashboard table.emails tr:not(.new) *:not(.n-submissions) a:not(*:hover) {
+      color: inherit; }
+    .dashboard table.emails tr:nth-child(2) td {
+      padding-top: 10px; }
+    .dashboard table.emails td:last-child {
+      text-align: center; }
+  .dashboard .create-form {
+    margin: 3em 0; }
+    .dashboard .create-form form {
+      clear: both; }
+    .dashboard .create-form form input:not([type="checkbox"]):not([type="radio"]) {
+      margin-top: 0;
+      clear: both;
+      width: 100%;
+      vertical-align: top; }
+    .dashboard .create-form form button {
+      padding: 0.63em 32px;
+      text-align: center; }
+    .dashboard .create-form .info {
+      font-size: 13px;
+      margin-bottom: 10px;
+      text-align: right; }
+    .dashboard .create-form .modal:not(.js):target > *,
+    .dashboard .create-form .modal.target > * {
+      top: 20%; }
+  .dashboard .modal[id^="form-"] textarea {
     font-size: 15px; }
-  .dashboard table.forms tr:not(.new) *:not(.n-submissions) a:not(*:hover), .dashboard table.emails tr:not(.new) *:not(.n-submissions) a:not(*:hover) {
-    color: inherit; }
-  .dashboard table.emails tr:nth-child(2) td {
-    padding-top: 10px; }
-  .dashboard table.emails td:last-child {
-    text-align: center; }
-.dashboard .create-form {
-  margin: 3em 0; }
-  .dashboard .create-form form {
-    clear: both; }
-  .dashboard .create-form form input:not([type="checkbox"]):not([type="radio"]) {
-    margin-top: 0;
-    clear: both;
-    width: 100%;
-    vertical-align: top; }
-  .dashboard .create-form form button {
-    padding: 0.63em 32px;
-    text-align: center; }
-  .dashboard .create-form .info {
-    font-size: 13px;
-    margin-bottom: 10px;
-    text-align: right; }
-  .dashboard .create-form .modal:not(.js):target > *,
-  .dashboard .create-form .modal.target > * {
-    top: 20%; }
-.dashboard .modal[id^="form-"] textarea {
-  font-size: 15px; }
-.dashboard .modal > * {
-  background: #fefefe;
-  border: #333333 solid 1px;
-  border-radius: 5px;
-  margin-left: -385px;
-  position: fixed;
-  left: 50%;
-  top: -100%;
-  z-index: 11;
-  width: 770px;
-  -webkit-transform: translate(0, -500%);
-  -ms-transform: translate(0, -500%);
-  transform: translate(0, -500%);
-  -webkit-transition: -webkit-transform 0.3s ease-out;
-  -moz-transition: -moz-transform 0.3s ease-out;
-  -o-transition: -o-transform 0.3s ease-out;
-  transition: transform 0.3s ease-out;
-  padding: 0.3em 1.3em 1.3em 1.3em; }
-  .dashboard .modal > * .x a {
-    float: right;
-    padding: 10px;
-    font-size: 1.7em; }
-  .dashboard .modal > * h4 {
-    margin: 0;
-    padding: 0;
-    margin-top: 13px;
-    float: left; }
-.dashboard .modal:not(.js):target > *, .dashboard .modal.target > * {
-  -webkit-transform: translate(0, 0);
-  -ms-transform: translate(0, 0);
-  transform: translate(0, 0);
-  top: 10%; }
-.dashboard .modal:before {
-  content: "";
-  display: none;
-  background: rgba(0, 0, 0, 0.6);
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 10; }
-.dashboard .modal:not(.js):target:before, .dashboard .modal.target:before {
-  display: block; }
-.dashboard .modal .red {
-  color: #ff1708; }
+  .dashboard .modal > * {
+    background: #fefefe;
+    border: #333333 solid 1px;
+    border-radius: 5px;
+    margin-left: -385px;
+    position: fixed;
+    left: 50%;
+    top: -100%;
+    z-index: 11;
+    width: 770px;
+    -webkit-transform: translate(0, -500%);
+    -ms-transform: translate(0, -500%);
+    transform: translate(0, -500%);
+    -webkit-transition: -webkit-transform 0.3s ease-out;
+    -moz-transition: -moz-transform 0.3s ease-out;
+    -o-transition: -o-transform 0.3s ease-out;
+    transition: transform 0.3s ease-out;
+    padding: 0.3em 1.3em 1.3em 1.3em; }
+    .dashboard .modal > * .x a {
+      float: right;
+      padding: 10px;
+      font-size: 1.7em; }
+    .dashboard .modal > * h4 {
+      margin: 0;
+      padding: 0;
+      margin-top: 13px;
+      float: left; }
+  .dashboard .modal:not(.js):target > *,
+  .dashboard .modal.target > * {
+    -webkit-transform: translate(0, 0);
+    -ms-transform: translate(0, 0);
+    transform: translate(0, 0);
+    top: 10%; }
+  .dashboard .modal:before {
+    content: "";
+    display: none;
+    background: rgba(0, 0, 0, 0.6);
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 10; }
+  .dashboard .modal:not(.js):target:before, .dashboard .modal.target:before {
+    display: block; }
+  .dashboard .modal .red {
+    color: #ff1708; }
+  .dashboard .fa-unlock:hover::before {
+    content: "\f023"; }
+  .dashboard .fa-lock:hover::before {
+    content: "\f09c"; }
+  .dashboard .fa-trash-o:hover::before,
+  .dashboard .fa-trash:hover::before {
+    content: "\f071"; }
 
 .html-highlight {
   clear: both;
@@ -985,9 +1032,9 @@ body > nav {
 @media screen and (max-width: 40em) {
   body > nav.js {
     display: none; }
-
   .slicknav_menu {
     display: block; } }
+
 .slicknav_menu {
   background: #4CD1A7;
   /* our transcluded menu header ("Welcome...") */ }
@@ -1180,22 +1227,23 @@ button.toast-close-button {
   #toast-container > div {
     padding: 8px 8px 8px 50px;
     width: 11em; }
-
   #toast-container .toast-close-button {
     right: -0.2em;
     top: -0.2em; } }
+
 @media all and (min-width: 241px) and (max-width: 480px) {
   #toast-container > div {
     padding: 8px 8px 8px 50px;
     width: 18em; }
-
   #toast-container .toast-close-button {
     right: -0.2em;
     top: -0.2em; } }
+
 @media all and (min-width: 481px) and (max-width: 768px) {
   #toast-container > div {
     padding: 15px 15px 15px 50px;
     width: 25em; } }
+
 html {
   height: 100%; }
 
@@ -1365,6 +1413,7 @@ button, a.button {
     -webkit-transform: translate3d(0, 0, 0);
     -moz-transform: translate3d(0, 0, 0);
     opacity: 1; } }
+
 @-webkit-keyframes dropIn {
   0% {
     opacity: 0;
@@ -1374,6 +1423,7 @@ button, a.button {
     opacity: 1;
     -webkit-transform: translate3d(0, 0, 0);
     -moz-transform: translate3d(0, 0, 0); } }
+
 @-webkit-keyframes dropInLong {
   0% {
     opacity: 0;
@@ -1383,14 +1433,17 @@ button, a.button {
     opacity: 1;
     -webkit-transform: translate3d(0, 0, 0);
     -moz-transform: translate3d(0, 0, 0); } }
+
 @-webkit-keyframes rotate {
   100% {
     -webkit-transform: rotate(45deg);
     -moz-transform: rotate(45deg); } }
+
 @-webkit-keyframes rotateBack {
   100% {
     -webkit-transform: rotate(0deg);
     -moz-transform: rotate(0deg); } }
+
 .overlay {
   position: fixed;
   width: 100%;

--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -747,8 +747,10 @@ a.alert-box.success:hover {
   .dashboard .create-form form button {
     padding: 0.63em 32px;
     text-align: center; }
-  .dashboard .create-form .verify-info {
-    font-size: 13px; }
+  .dashboard .create-form .info {
+    font-size: 13px;
+    margin-bottom: 10px;
+    text-align: right; }
   .dashboard .create-form .modal:not(.js):target > *,
   .dashboard .create-form .modal.target > * {
     top: 20%; }
@@ -798,8 +800,6 @@ a.alert-box.success:hover {
   z-index: 10; }
 .dashboard .modal:not(.js):target:before, .dashboard .modal.target:before {
   display: block; }
-.dashboard .modal .small {
-  text-size: 80%; }
 .dashboard .modal .red {
   color: #ff1708; }
 
@@ -1416,5 +1416,3 @@ body.showOverlay .toggleOverlay {
   right: 30%;
   left: 30%;
   width: 40%; }
-
-/*# sourceMappingURL=main.css.map */

--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -791,6 +791,9 @@ a.alert-box.success:hover {
 .dashboard .modal:not(.js):target:before, .dashboard .modal.target:before {
   display: block; }
 
+.red {
+  color: #000; }
+
 .slicknav_btn {
   position: relative;
   display: block;

--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -723,7 +723,6 @@ a.alert-box.success:hover {
   .dashboard table.forms tr.new span[class^="ion-"], .dashboard table.emails tr.new span[class^="ion-"] {
     color: #ff1708; }
   .dashboard table.forms tr.new a:not(*:hover), .dashboard table.emails tr.new a:not(*:hover) {
-    color: inherit;
     display: block;
     border-bottom: 1px dotted;
     float: left;
@@ -731,6 +730,8 @@ a.alert-box.success:hover {
     line-height: 1em; }
   .dashboard table.forms tr.new .never, .dashboard table.emails tr.new .never {
     font-size: 15px; }
+  .dashboard table.forms tr:not(.new) *:not(.n-submissions) a:not(*:hover), .dashboard table.emails tr:not(.new) *:not(.n-submissions) a:not(*:hover) {
+    color: inherit; }
   .dashboard table.emails tr:nth-child(2) td {
     padding-top: 10px; }
   .dashboard table.emails td:last-child {

--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -716,12 +716,12 @@ a.alert-box.success:hover {
     word-break: break-word; }
   .dashboard table.forms td.n-submissions, .dashboard table.emails td.n-submissions {
     min-width: 150px; }
-  .dashboard table.forms tr.verified span[class^="ion-"], .dashboard table.emails tr.verified span[class^="ion-"] {
-    color: #2A735B; }
-  .dashboard table.forms tr.waiting_confirmation span[class^="ion-"], .dashboard table.emails tr.waiting_confirmation span[class^="ion-"] {
-    color: #D87431; }
   .dashboard table.forms tr.new span[class^="ion-"], .dashboard table.emails tr.new span[class^="ion-"] {
     color: #ff1708; }
+  .dashboard table.forms tr.waiting_confirmation span[class^="ion-"], .dashboard table.emails tr.waiting_confirmation span[class^="ion-"] {
+    color: #D87431; }
+  .dashboard table.forms tr.verified span[class^="ion-"], .dashboard table.emails tr.verified span[class^="ion-"] {
+    color: #2A735B; }
   .dashboard table.forms tr.new a:not(*:hover), .dashboard table.emails tr.new a:not(*:hover) {
     display: block;
     border-bottom: 1px dotted;

--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -689,11 +689,11 @@ a.alert-box.success:hover {
   text-align: center;
   width: 32px; }
 .dashboard .delete {
-  color: #D9534F;
-  border-color: #D9534F; }
+  color: #ff1708;
+  border-color: #ff1708; }
 .dashboard .delete:hover {
   transition: color 0.3s ease-in-out;
-  color: #d1332e; }
+  color: #D87431; }
 .dashboard table {
   text-align: left;
   width: 100%; }

--- a/formspree/static/js/bundle.js
+++ b/formspree/static/js/bundle.js
@@ -47,18 +47,29 @@ function modals() {
     modal.click(function (e) {
       // close the modal
       if (e.target === modal[0]) {
-        if (window.location.hash) window.location.hash = '';
+        cleanHash();
         modal.toggleClass('target');
         e.preventDefault();
       }
     });
     modal.find('.x a').click(function (e) {
       // close the modal
-      if (window.location.hash) window.location.hash = '';
+      cleanHash();
       e.preventDefault();
       modal.toggleClass('target');
     });
   });
+
+  function cleanHash() {
+    if (!window.location.hash) return;
+    if (window.history && window.history.replaceState) {
+      window.history.replaceState('', document.title, window.location.pathname);
+    } else {
+      var pos = $(window).scrollTop();
+      window.location.hash = '';
+      $(window).scrollTop(pos);
+    }
+  }
 
   // activate modals from url hash #
   setTimeout(function () {

--- a/formspree/static/js/bundle.js
+++ b/formspree/static/js/bundle.js
@@ -162,6 +162,7 @@ module.exports = function sitewide() {
 
     var email = parentNode.find('input[name="email"]').val().trim();
     var urlv = parentNode.find('input[name="url"]').val().trim();
+    urlv = /^https?:\/\//.test(urlv) ? urlv : 'http://' + urlv;
     var sitewide = checkbox.is(':checked');
 
     // wrong input
@@ -223,7 +224,7 @@ module.exports = function sitewide() {
     var email = _ref.email;
     var disableVerification = _ref.disableVerification;
 
-    return h('form', { method: 'post', action: formActionURL }, [h('.col-1-1', [h('h4', 'Send email to:'), h('input', { type: 'email', name: 'email', placeholder: emailPlaceholder, value: email })]), h('.col-1-1', [h('h4', 'From URL:'), h('input', { type: 'url', name: 'url', placeholder: urlPlaceholder })]), h('.container', [h('.col-1-4', [h('label.hint--bottom', { dataset: { hint: sitewideHint } }, [h('input', { type: 'checkbox', name: 'sitewide', value: 'true' }), ' site-wide'])]), h('.col-3-4.info', [invalid ? h('div.red', invalid === 'email' ? 'Please input a valid email address.' : ['Please input a valid URL. For example: ', h('span.code', url.resolve('http://www.mywebsite.com', sitewide ? '' : '/contact.html'))]) : sitewide && verified || !sitewide ? h('div', { innerHTML: '&#8203;' }) : h('span', ['Please ensure ', h('span.code', url.resolve(urlv, '/formspree-verify.txt')), ' exists and contains a line with ', h('span.code', email)])]), h('.col-1-3', [h('.verify', [h('button', sitewide && !invalid && !disableVerification ? {} : sitewide ? { disabled: true } : { style: { visibility: 'hidden' }, disabled: true }, 'Verify')])]), h('.col-1-3', { innerHTML: '&#8203;' }), h('.col-1-3', [h('.create', [sitewide && verified || !sitewide && !invalid ? h('button', { type: 'submit' }, 'Create form') : h('button', { disabled: true }, 'Create form')])])])]);
+    return h('form', { method: 'post', action: formActionURL }, [h('.col-1-1', [h('h4', 'Send email to:'), h('input', { type: 'email', name: 'email', placeholder: emailPlaceholder, value: email })]), h('.col-1-1', [h('h4', 'From URL:'), h('input', { type: 'text', name: 'url', placeholder: urlPlaceholder })]), h('.container', [h('.col-1-4', [h('label.hint--bottom', { dataset: { hint: sitewideHint } }, [h('input', { type: 'checkbox', name: 'sitewide', value: 'true' }), ' site-wide'])]), h('.col-3-4.info', [invalid ? h('div.red', invalid === 'email' ? 'Please input a valid email address.' : ['Please input a valid URL. For example: ', h('span.code', url.resolve('http://www.mywebsite.com', sitewide ? '' : '/contact.html'))]) : sitewide && verified || !sitewide ? h('div', { innerHTML: '&#8203;' }) : h('span', ['Please ensure ', h('span.code', url.resolve(urlv, '/formspree-verify.txt')), ' exists and contains a line with ', h('span.code', email)])]), h('.col-1-3', [h('.verify', [h('button', sitewide && !invalid && !disableVerification ? {} : sitewide ? { disabled: true } : { style: { visibility: 'hidden' }, disabled: true }, 'Verify')])]), h('.col-1-3', { innerHTML: '&#8203;' }), h('.col-1-3', [h('.create', [sitewide && verified || !sitewide && !invalid ? h('button', { type: 'submit' }, 'Create form') : h('button', { disabled: true }, 'Create form')])])])]);
   }
 };
 
@@ -451,7 +452,7 @@ module.exports = function isObject(x) {
 
 },{}],11:[function(require,module,exports){
 (function (global){
-/*! https://mths.be/punycode v1.4.0 by @mathias */
+/*! https://mths.be/punycode v1.3.2 by @mathias */
 ;(function(root) {
 
 	/** Detect free variables */
@@ -517,7 +518,7 @@ module.exports = function isObject(x) {
 	 * @returns {Error} Throws a `RangeError` with the applicable error message.
 	 */
 	function error(type) {
-		throw new RangeError(errors[type]);
+		throw RangeError(errors[type]);
 	}
 
 	/**
@@ -664,7 +665,7 @@ module.exports = function isObject(x) {
 
 	/**
 	 * Bias adaptation function as per section 3.4 of RFC 3492.
-	 * https://tools.ietf.org/html/rfc3492#section-3.4
+	 * http://tools.ietf.org/html/rfc3492#section-3.4
 	 * @private
 	 */
 	function adapt(delta, numPoints, firstTime) {
@@ -969,17 +970,14 @@ module.exports = function isObject(x) {
 			return punycode;
 		});
 	} else if (freeExports && freeModule) {
-		if (module.exports == freeExports) {
-			// in Node.js, io.js, or RingoJS v0.8.0+
+		if (module.exports == freeExports) { // in Node.js or RingoJS v0.8.0+
 			freeModule.exports = punycode;
-		} else {
-			// in Narwhal or RingoJS v0.7.0-
+		} else { // in Narwhal or RingoJS v0.7.0-
 			for (key in punycode) {
 				punycode.hasOwnProperty(key) && (freeExports[key] = punycode[key]);
 			}
 		}
-	} else {
-		// in Rhino or a web browser
+	} else { // in Rhino or a web browser
 		root.punycode = punycode;
 	}
 

--- a/formspree/static/js/bundle.js
+++ b/formspree/static/js/bundle.js
@@ -37,17 +37,24 @@ function modals() {
     var modal = $(this);
     modal.addClass('js');
     var id = modal.attr('id');
+
     $('[href="#' + id + '"]').click(function (e) {
+      // open the modal
       e.preventDefault();
       modal.toggleClass('target');
     });
+
     modal.click(function (e) {
+      // close the modal
       if (e.target === modal[0]) {
+        if (window.location.hash) window.location.hash = '';
         modal.toggleClass('target');
         e.preventDefault();
       }
     });
     modal.find('.x a').click(function (e) {
+      // close the modal
+      if (window.location.hash) window.location.hash = '';
       e.preventDefault();
       modal.toggleClass('target');
     });

--- a/formspree/static/js/bundle.js
+++ b/formspree/static/js/bundle.js
@@ -1,9 +1,6 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 'use strict';
 
-var url = require('url');
-var isValidEmail = require('is-valid-email');
-
 var $ = window.$;
 var StripeCheckout = window.StripeCheckout;
 var toastr = window.toastr;
@@ -68,72 +65,6 @@ function modals() {
 }
 modals();
 
-/* create-form validation for site-wide forms */
-function sitewide() {
-  var createform = $('#create-form');
-  var emailInput = createform.find('input[name="email"]');
-  var urlInput = createform.find('input[name="url"]');
-  var checkbox = createform.find('input[name="sitewide"]');
-  var verifyButton = createform.find('.verify-button');
-  var createButton = createform.find('.create-button');
-  var info = createform.find('.verify-info');
-
-  checkbox.on('change', run);
-  emailInput.on('input', run);
-  urlInput.on('input', run);
-
-  function run() {
-    if (checkbox.is(':checked')) {
-      var email = emailInput.val().trim();
-      var urlp = url.parse(urlInput.val().trim());
-
-      if (isValidEmail(email) && urlp.host) {
-        var sitewideFile = 'formspree_verify_' + email + '.txt';
-        verifyButton.css('visibility', 'visible');
-        info.html('Please ensure <span class="code">' + url.resolve(urlInput.val(), '/' + sitewideFile) + '</span> exists');
-      } else {
-        // wrong input
-        if (!urlp.host) {
-          // invalid url
-          info.text('Please input a valid URL.');
-        } else {
-          // invalid email
-          info.text('Please input a valid email address.');
-        }
-      }
-
-      createButton.find('button').prop('disabled', true);
-      info.css('visibility', 'visible');
-    } else {
-      // toggle sitewide off
-      info.css('visibility', 'hidden');
-      verifyButton.css('visibility', 'hidden');
-      createButton.css('visibility', 'visible');
-    }
-  }
-
-  verifyButton.find('button').on('click', function () {
-    $.ajax({
-      url: '/forms/sitewide-check?' + createform.find('form').serialize(),
-      success: function success() {
-        toastr.success('The file exists! you can create your site-wide form now.');
-        createButton.find('button').prop('disabled', false);
-        verifyButton.css('visibility', 'hidden');
-        info.css('visibility', 'hidden');
-      },
-      error: function error() {
-        toastr.warning("The verification file wasn't found.");
-        verifyButton.find('button').prop('disabled', true);
-        setTimeout(function () {
-          verifyButton.find('button').prop('disabled', false);
-        }, 5000);
-      }
-    });
-    return false;
-  });
-}
-sitewide();
-
 /* turning flask flash messages into js popup notifications */
 window.popupMessages.forEach(function (m, i) {
   var category = m[0] || 'info';
@@ -163,7 +94,324 @@ $('a.resend').on('click', function () {
   $('form.resend').show();
 });
 
-},{"is-valid-email":2,"url":7}],2:[function(require,module,exports){
+/* scripts at other files */
+require('./sitewide')();
+
+},{"./sitewide":2}],2:[function(require,module,exports){
+'use strict';
+
+var url = require('url');
+var isValidUrl = require('valid-url').isWebUri;
+var isValidEmail = require('is-valid-email');
+
+var h = require('virtual-dom/h');
+var diff = require('virtual-dom/diff');
+var patch = require('virtual-dom/patch');
+var createElement = require('virtual-dom/create-element');
+
+var $ = window.$;
+var toastr = window.toastr;
+
+/* create-form validation for site-wide forms */
+module.exports = function sitewide() {
+  var parentNode = $('#create-form .container');
+
+  var formActionURL = parentNode.find('form').attr('action');
+  var currentUserEmail = parentNode.find('[name="email"]').val();
+
+  // since we have javascript, let's trash this HTML and recreate with virtual-dom
+  parentNode.html('');
+
+  var data = {
+    invalid: null,
+    sitewide: false,
+    verified: false,
+    email: currentUserEmail
+  };
+  var tree = render(data);
+  var rootNode = createElement(tree);
+  parentNode[0].appendChild(rootNode);
+
+  parentNode.on('change', 'input[name="sitewide"]', run);
+  parentNode.on('input', 'input[name="url"], input[name="email"]', run);
+  parentNode.on('click', '.verify button', check);
+
+  function run() {
+    var checkbox = parentNode.find('input[name="sitewide"]');
+
+    var email = parentNode.find('input[name="email"]').val().trim();
+    var urlv = parentNode.find('input[name="url"]').val().trim();
+    var sitewide = checkbox.is(':checked');
+
+    // wrong input
+    if (!isValidEmail(email)) {
+      // invalid email
+      data.invalid = 'email';
+    } else if (sitewide && !isValidUrl(urlv)) {
+      // invalid url with sitewide
+      data.invalid = 'url';
+    } else if (!sitewide && urlv && !isValidUrl(urlv)) {
+      // invalid url without sitewide
+      data.invalid = 'url';
+    } else {
+      data.invalid = null;
+    }
+
+    data.sitewide = sitewide;
+    data.urlv = urlv;
+    data.email = email;
+
+    apply(render(data));
+  }
+
+  function check() {
+    $.ajax({
+      url: '/forms/sitewide-check?' + parentNode.find('form').serialize(),
+      success: function success() {
+        toastr.success('The file exists! you can create your site-wide form now.');
+        data.verified = true;
+        apply(render(data));
+      },
+      error: function error() {
+        toastr.warning("The verification file wasn't found.");
+        data.verified = false;
+        data.disableVerification = true;
+        apply(render(data));
+
+        setTimeout(function () {
+          data.disableVerification = false;
+          apply(render(data));
+        }, 5000);
+      }
+    });
+
+    return false;
+  }
+
+  function apply(vtree) {
+    var patches = diff(tree, vtree);
+    rootNode = patch(rootNode, patches);
+    tree = vtree;
+  }
+
+  function render(_ref) {
+    var invalid = _ref.invalid;
+    var sitewide = _ref.sitewide;
+    var verified = _ref.verified;
+    var urlv = _ref.urlv;
+    var email = _ref.email;
+    var disableVerification = _ref.disableVerification;
+
+    return h('form', { method: 'post', action: formActionURL }, [h('.col-1-1', [h('h4', 'Send email to:'), h('input', { type: 'email', name: 'email', placeholder: 'You can point this form to any email address', value: email })]), h('.col-1-1', [h('h4', 'From URL:'), h('input', { type: 'url', name: 'url', placeholder: 'Leave blank to send confirmation email when first submitted' })]), h('.container', [h('.col-1-4', [h('label.hint--bottom', { dataset: { hint: 'A site-wide form is a form that you can place on all pages of your website -- and you just have to confirm once!' } }, [h('input', { type: 'checkbox', name: 'sitewide', value: 'true' }), ' site-wide'])]), h('.col-3-4', [invalid ? h('div.red', invalid === 'email' ? 'Please input a valid email address.' : ['Please input a valid URL. For example: ', h('span.code', url.resolve('http://www.mywebsite.com', sitewide ? '' : '/contact.html'))]) : sitewide && verified || !sitewide ? h('div', { innerHTML: '&#8203;' }) : h('span', ['Please ensure ', h('span.code', url.resolve(urlv, '/formspree-verify.txt')), ' exists and contains a line with ', h('span.code', email)])]), h('.col-1-3', [h('.verify', [h('button', sitewide && !invalid && !disableVerification ? {} : sitewide ? { disabled: true } : { style: { visibility: 'hidden' }, disabled: true }, 'Verify')])]), h('.col-1-3', { innerHTML: '&#8203;' }), h('.col-1-3', [h('.create', [sitewide && verified || !sitewide && !invalid ? h('button', { type: 'submit' }, 'Create form') : h('button', { disabled: true }, 'Create form')])])])]);
+  }
+};
+
+},{"is-valid-email":10,"url":15,"valid-url":17,"virtual-dom/create-element":18,"virtual-dom/diff":19,"virtual-dom/h":20,"virtual-dom/patch":21}],3:[function(require,module,exports){
+
+},{}],4:[function(require,module,exports){
+/*!
+ * Cross-Browser Split 1.1.1
+ * Copyright 2007-2012 Steven Levithan <stevenlevithan.com>
+ * Available under the MIT License
+ * ECMAScript compliant, uniform cross-browser split method
+ */
+
+/**
+ * Splits a string into an array of strings using a regex or string separator. Matches of the
+ * separator are not included in the result array. However, if `separator` is a regex that contains
+ * capturing groups, backreferences are spliced into the result each time `separator` is matched.
+ * Fixes browser bugs compared to the native `String.prototype.split` and can be used reliably
+ * cross-browser.
+ * @param {String} str String to split.
+ * @param {RegExp|String} separator Regex or string to use for separating the string.
+ * @param {Number} [limit] Maximum number of items to include in the result array.
+ * @returns {Array} Array of substrings.
+ * @example
+ *
+ * // Basic use
+ * split('a b c d', ' ');
+ * // -> ['a', 'b', 'c', 'd']
+ *
+ * // With limit
+ * split('a b c d', ' ', 2);
+ * // -> ['a', 'b']
+ *
+ * // Backreferences in result array
+ * split('..word1 word2..', /([a-z]+)(\d+)/i);
+ * // -> ['..', 'word', '1', ' ', 'word', '2', '..']
+ */
+module.exports = (function split(undef) {
+
+  var nativeSplit = String.prototype.split,
+    compliantExecNpcg = /()??/.exec("")[1] === undef,
+    // NPCG: nonparticipating capturing group
+    self;
+
+  self = function(str, separator, limit) {
+    // If `separator` is not a regex, use `nativeSplit`
+    if (Object.prototype.toString.call(separator) !== "[object RegExp]") {
+      return nativeSplit.call(str, separator, limit);
+    }
+    var output = [],
+      flags = (separator.ignoreCase ? "i" : "") + (separator.multiline ? "m" : "") + (separator.extended ? "x" : "") + // Proposed for ES6
+      (separator.sticky ? "y" : ""),
+      // Firefox 3+
+      lastLastIndex = 0,
+      // Make `global` and avoid `lastIndex` issues by working with a copy
+      separator = new RegExp(separator.source, flags + "g"),
+      separator2, match, lastIndex, lastLength;
+    str += ""; // Type-convert
+    if (!compliantExecNpcg) {
+      // Doesn't need flags gy, but they don't hurt
+      separator2 = new RegExp("^" + separator.source + "$(?!\\s)", flags);
+    }
+    /* Values for `limit`, per the spec:
+     * If undefined: 4294967295 // Math.pow(2, 32) - 1
+     * If 0, Infinity, or NaN: 0
+     * If positive number: limit = Math.floor(limit); if (limit > 4294967295) limit -= 4294967296;
+     * If negative number: 4294967296 - Math.floor(Math.abs(limit))
+     * If other: Type-convert, then use the above rules
+     */
+    limit = limit === undef ? -1 >>> 0 : // Math.pow(2, 32) - 1
+    limit >>> 0; // ToUint32(limit)
+    while (match = separator.exec(str)) {
+      // `separator.lastIndex` is not reliable cross-browser
+      lastIndex = match.index + match[0].length;
+      if (lastIndex > lastLastIndex) {
+        output.push(str.slice(lastLastIndex, match.index));
+        // Fix browsers whose `exec` methods don't consistently return `undefined` for
+        // nonparticipating capturing groups
+        if (!compliantExecNpcg && match.length > 1) {
+          match[0].replace(separator2, function() {
+            for (var i = 1; i < arguments.length - 2; i++) {
+              if (arguments[i] === undef) {
+                match[i] = undef;
+              }
+            }
+          });
+        }
+        if (match.length > 1 && match.index < str.length) {
+          Array.prototype.push.apply(output, match.slice(1));
+        }
+        lastLength = match[0].length;
+        lastLastIndex = lastIndex;
+        if (output.length >= limit) {
+          break;
+        }
+      }
+      if (separator.lastIndex === match.index) {
+        separator.lastIndex++; // Avoid an infinite loop
+      }
+    }
+    if (lastLastIndex === str.length) {
+      if (lastLength || !separator.test("")) {
+        output.push("");
+      }
+    } else {
+      output.push(str.slice(lastLastIndex));
+    }
+    return output.length > limit ? output.slice(0, limit) : output;
+  };
+
+  return self;
+})();
+
+},{}],5:[function(require,module,exports){
+'use strict';
+
+var OneVersionConstraint = require('individual/one-version');
+
+var MY_VERSION = '7';
+OneVersionConstraint('ev-store', MY_VERSION);
+
+var hashKey = '__EV_STORE_KEY@' + MY_VERSION;
+
+module.exports = EvStore;
+
+function EvStore(elem) {
+    var hash = elem[hashKey];
+
+    if (!hash) {
+        hash = elem[hashKey] = {};
+    }
+
+    return hash;
+}
+
+},{"individual/one-version":8}],6:[function(require,module,exports){
+(function (global){
+var topLevel = typeof global !== 'undefined' ? global :
+    typeof window !== 'undefined' ? window : {}
+var minDoc = require('min-document');
+
+if (typeof document !== 'undefined') {
+    module.exports = document;
+} else {
+    var doccy = topLevel['__GLOBAL_DOCUMENT_CACHE@4'];
+
+    if (!doccy) {
+        doccy = topLevel['__GLOBAL_DOCUMENT_CACHE@4'] = minDoc;
+    }
+
+    module.exports = doccy;
+}
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{"min-document":3}],7:[function(require,module,exports){
+(function (global){
+'use strict';
+
+/*global window, global*/
+
+var root = typeof window !== 'undefined' ?
+    window : typeof global !== 'undefined' ?
+    global : {};
+
+module.exports = Individual;
+
+function Individual(key, value) {
+    if (key in root) {
+        return root[key];
+    }
+
+    root[key] = value;
+
+    return value;
+}
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{}],8:[function(require,module,exports){
+'use strict';
+
+var Individual = require('./index.js');
+
+module.exports = OneVersion;
+
+function OneVersion(moduleName, version, defaultValue) {
+    var key = '__INDIVIDUAL_ONE_VERSION_' + moduleName;
+    var enforceKey = key + '_ENFORCE_SINGLETON';
+
+    var versionValue = Individual(enforceKey, version);
+
+    if (versionValue !== version) {
+        throw new Error('Can only have one copy of ' +
+            moduleName + '.\n' +
+            'You already have version ' + versionValue +
+            ' installed.\n' +
+            'This means you cannot install version ' + version);
+    }
+
+    return Individual(key, defaultValue);
+}
+
+},{"./index.js":7}],9:[function(require,module,exports){
+"use strict";
+
+module.exports = function isObject(x) {
+	return typeof x === "object" && x !== null;
+};
+
+},{}],10:[function(require,module,exports){
 (function(){
 
   function isValidEmail(v) {
@@ -180,7 +428,7 @@ $('a.resend').on('click', function () {
 
 })();
 
-},{}],3:[function(require,module,exports){
+},{}],11:[function(require,module,exports){
 (function (global){
 /*! https://mths.be/punycode v1.4.0 by @mathias */
 ;(function(root) {
@@ -717,7 +965,7 @@ $('a.resend').on('click', function () {
 }(this));
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],4:[function(require,module,exports){
+},{}],12:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -803,7 +1051,7 @@ var isArray = Array.isArray || function (xs) {
   return Object.prototype.toString.call(xs) === '[object Array]';
 };
 
-},{}],5:[function(require,module,exports){
+},{}],13:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -890,13 +1138,13 @@ var objectKeys = Object.keys || function (obj) {
   return res;
 };
 
-},{}],6:[function(require,module,exports){
+},{}],14:[function(require,module,exports){
 'use strict';
 
 exports.decode = exports.parse = require('./decode');
 exports.encode = exports.stringify = require('./encode');
 
-},{"./decode":4,"./encode":5}],7:[function(require,module,exports){
+},{"./decode":12,"./encode":13}],15:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -1630,7 +1878,7 @@ Url.prototype.parseHost = function() {
   if (host) this.hostname = host;
 };
 
-},{"./util":8,"punycode":3,"querystring":6}],8:[function(require,module,exports){
+},{"./util":16,"punycode":11,"querystring":14}],16:[function(require,module,exports){
 'use strict';
 
 module.exports = {
@@ -1647,5 +1895,1604 @@ module.exports = {
     return arg == null;
   }
 };
+
+},{}],17:[function(require,module,exports){
+(function(module) {
+    'use strict';
+
+    module.exports.is_uri = is_iri;
+    module.exports.is_http_uri = is_http_iri;
+    module.exports.is_https_uri = is_https_iri;
+    module.exports.is_web_uri = is_web_iri;
+    // Create aliases
+    module.exports.isUri = is_iri;
+    module.exports.isHttpUri = is_http_iri;
+    module.exports.isHttpsUri = is_https_iri;
+    module.exports.isWebUri = is_web_iri;
+
+
+    // private function
+    // internal URI spitter method - direct from RFC 3986
+    var splitUri = function(uri) {
+        var splitted = uri.match(/(?:([^:\/?#]+):)?(?:\/\/([^\/?#]*))?([^?#]*)(?:\?([^#]*))?(?:#(.*))?/);
+        return splitted;
+    };
+
+    function is_iri(value) {
+        if (!value) {
+            return;
+        }
+
+        // check for illegal characters
+        if (/[^a-z0-9\:\/\?\#\[\]\@\!\$\&\'\(\)\*\+\,\;\=\.\-\_\~\%]/i.test(value)) return;
+
+        // check for hex escapes that aren't complete
+        if (/%[^0-9a-f]/i.test(value)) return;
+        if (/%[0-9a-f](:?[^0-9a-f]|$)/i.test(value)) return;
+
+        var splitted = [];
+        var scheme = '';
+        var authority = '';
+        var path = '';
+        var query = '';
+        var fragment = '';
+        var out = '';
+
+        // from RFC 3986
+        splitted = splitUri(value);
+        scheme = splitted[1]; 
+        authority = splitted[2];
+        path = splitted[3];
+        query = splitted[4];
+        fragment = splitted[5];
+
+        // scheme and path are required, though the path can be empty
+        if (!(scheme && scheme.length && path.length >= 0)) return;
+
+        // if authority is present, the path must be empty or begin with a /
+        if (authority && authority.length) {
+            if (!(path.length === 0 || /^\//.test(path))) return;
+        } else {
+            // if authority is not present, the path must not start with //
+            if (/^\/\//.test(path)) return;
+        }
+
+        // scheme must begin with a letter, then consist of letters, digits, +, ., or -
+        if (!/^[a-z][a-z0-9\+\-\.]*$/.test(scheme.toLowerCase()))  return;
+
+        // re-assemble the URL per section 5.3 in RFC 3986
+        out += scheme + ':';
+        if (authority && authority.length) {
+            out += '//' + authority;
+        }
+
+        out += path;
+
+        if (query && query.length) {
+            out += '?' + query;
+        }
+
+        if (fragment && fragment.length) {
+            out += '#' + fragment;
+        }
+
+        return out;
+    }
+
+    function is_http_iri(value, allowHttps) {
+        if (!is_iri(value)) {
+            return;
+        }
+
+        var splitted = [];
+        var scheme = '';
+        var authority = '';
+        var path = '';
+        var port = '';
+        var query = '';
+        var fragment = '';
+        var out = '';
+
+        // from RFC 3986
+        splitted = splitUri(value);
+        scheme = splitted[1]; 
+        authority = splitted[2];
+        path = splitted[3];
+        query = splitted[4];
+        fragment = splitted[5];
+
+        if (!scheme)  return;
+
+        if(allowHttps) {
+            if (scheme.toLowerCase() != 'https') return;
+        } else {
+            if (scheme.toLowerCase() != 'http') return;
+        }
+
+        // fully-qualified URIs must have an authority section that is
+        // a valid host
+        if (!authority) {
+            return;
+        }
+
+        // enable port component
+        if (/:(\d+)$/.test(authority)) {
+            port = authority.match(/:(\d+)$/)[0];
+            authority = authority.replace(/:\d+$/, '');
+        }
+
+        out += scheme + ':';
+        out += '//' + authority;
+        
+        if (port) {
+            out += port;
+        }
+        
+        out += path;
+        
+        if(query && query.length){
+            out += '?' + query;
+        }
+
+        if(fragment && fragment.length){
+            out += '#' + fragment;
+        }
+        
+        return out;
+    }
+
+    function is_https_iri(value) {
+        return is_http_iri(value, true);
+    }
+
+    function is_web_iri(value) {
+        return (is_http_iri(value) || is_https_iri(value));
+    }
+
+})(module);
+
+},{}],18:[function(require,module,exports){
+var createElement = require("./vdom/create-element.js")
+
+module.exports = createElement
+
+},{"./vdom/create-element.js":23}],19:[function(require,module,exports){
+var diff = require("./vtree/diff.js")
+
+module.exports = diff
+
+},{"./vtree/diff.js":43}],20:[function(require,module,exports){
+var h = require("./virtual-hyperscript/index.js")
+
+module.exports = h
+
+},{"./virtual-hyperscript/index.js":30}],21:[function(require,module,exports){
+var patch = require("./vdom/patch.js")
+
+module.exports = patch
+
+},{"./vdom/patch.js":26}],22:[function(require,module,exports){
+var isObject = require("is-object")
+var isHook = require("../vnode/is-vhook.js")
+
+module.exports = applyProperties
+
+function applyProperties(node, props, previous) {
+    for (var propName in props) {
+        var propValue = props[propName]
+
+        if (propValue === undefined) {
+            removeProperty(node, propName, propValue, previous);
+        } else if (isHook(propValue)) {
+            removeProperty(node, propName, propValue, previous)
+            if (propValue.hook) {
+                propValue.hook(node,
+                    propName,
+                    previous ? previous[propName] : undefined)
+            }
+        } else {
+            if (isObject(propValue)) {
+                patchObject(node, props, previous, propName, propValue);
+            } else {
+                node[propName] = propValue
+            }
+        }
+    }
+}
+
+function removeProperty(node, propName, propValue, previous) {
+    if (previous) {
+        var previousValue = previous[propName]
+
+        if (!isHook(previousValue)) {
+            if (propName === "attributes") {
+                for (var attrName in previousValue) {
+                    node.removeAttribute(attrName)
+                }
+            } else if (propName === "style") {
+                for (var i in previousValue) {
+                    node.style[i] = ""
+                }
+            } else if (typeof previousValue === "string") {
+                node[propName] = ""
+            } else {
+                node[propName] = null
+            }
+        } else if (previousValue.unhook) {
+            previousValue.unhook(node, propName, propValue)
+        }
+    }
+}
+
+function patchObject(node, props, previous, propName, propValue) {
+    var previousValue = previous ? previous[propName] : undefined
+
+    // Set attributes
+    if (propName === "attributes") {
+        for (var attrName in propValue) {
+            var attrValue = propValue[attrName]
+
+            if (attrValue === undefined) {
+                node.removeAttribute(attrName)
+            } else {
+                node.setAttribute(attrName, attrValue)
+            }
+        }
+
+        return
+    }
+
+    if(previousValue && isObject(previousValue) &&
+        getPrototype(previousValue) !== getPrototype(propValue)) {
+        node[propName] = propValue
+        return
+    }
+
+    if (!isObject(node[propName])) {
+        node[propName] = {}
+    }
+
+    var replacer = propName === "style" ? "" : undefined
+
+    for (var k in propValue) {
+        var value = propValue[k]
+        node[propName][k] = (value === undefined) ? replacer : value
+    }
+}
+
+function getPrototype(value) {
+    if (Object.getPrototypeOf) {
+        return Object.getPrototypeOf(value)
+    } else if (value.__proto__) {
+        return value.__proto__
+    } else if (value.constructor) {
+        return value.constructor.prototype
+    }
+}
+
+},{"../vnode/is-vhook.js":34,"is-object":9}],23:[function(require,module,exports){
+var document = require("global/document")
+
+var applyProperties = require("./apply-properties")
+
+var isVNode = require("../vnode/is-vnode.js")
+var isVText = require("../vnode/is-vtext.js")
+var isWidget = require("../vnode/is-widget.js")
+var handleThunk = require("../vnode/handle-thunk.js")
+
+module.exports = createElement
+
+function createElement(vnode, opts) {
+    var doc = opts ? opts.document || document : document
+    var warn = opts ? opts.warn : null
+
+    vnode = handleThunk(vnode).a
+
+    if (isWidget(vnode)) {
+        return vnode.init()
+    } else if (isVText(vnode)) {
+        return doc.createTextNode(vnode.text)
+    } else if (!isVNode(vnode)) {
+        if (warn) {
+            warn("Item is not a valid virtual dom node", vnode)
+        }
+        return null
+    }
+
+    var node = (vnode.namespace === null) ?
+        doc.createElement(vnode.tagName) :
+        doc.createElementNS(vnode.namespace, vnode.tagName)
+
+    var props = vnode.properties
+    applyProperties(node, props)
+
+    var children = vnode.children
+
+    for (var i = 0; i < children.length; i++) {
+        var childNode = createElement(children[i], opts)
+        if (childNode) {
+            node.appendChild(childNode)
+        }
+    }
+
+    return node
+}
+
+},{"../vnode/handle-thunk.js":32,"../vnode/is-vnode.js":35,"../vnode/is-vtext.js":36,"../vnode/is-widget.js":37,"./apply-properties":22,"global/document":6}],24:[function(require,module,exports){
+// Maps a virtual DOM tree onto a real DOM tree in an efficient manner.
+// We don't want to read all of the DOM nodes in the tree so we use
+// the in-order tree indexing to eliminate recursion down certain branches.
+// We only recurse into a DOM node if we know that it contains a child of
+// interest.
+
+var noChild = {}
+
+module.exports = domIndex
+
+function domIndex(rootNode, tree, indices, nodes) {
+    if (!indices || indices.length === 0) {
+        return {}
+    } else {
+        indices.sort(ascending)
+        return recurse(rootNode, tree, indices, nodes, 0)
+    }
+}
+
+function recurse(rootNode, tree, indices, nodes, rootIndex) {
+    nodes = nodes || {}
+
+
+    if (rootNode) {
+        if (indexInRange(indices, rootIndex, rootIndex)) {
+            nodes[rootIndex] = rootNode
+        }
+
+        var vChildren = tree.children
+
+        if (vChildren) {
+
+            var childNodes = rootNode.childNodes
+
+            for (var i = 0; i < tree.children.length; i++) {
+                rootIndex += 1
+
+                var vChild = vChildren[i] || noChild
+                var nextIndex = rootIndex + (vChild.count || 0)
+
+                // skip recursion down the tree if there are no nodes down here
+                if (indexInRange(indices, rootIndex, nextIndex)) {
+                    recurse(childNodes[i], vChild, indices, nodes, rootIndex)
+                }
+
+                rootIndex = nextIndex
+            }
+        }
+    }
+
+    return nodes
+}
+
+// Binary search for an index in the interval [left, right]
+function indexInRange(indices, left, right) {
+    if (indices.length === 0) {
+        return false
+    }
+
+    var minIndex = 0
+    var maxIndex = indices.length - 1
+    var currentIndex
+    var currentItem
+
+    while (minIndex <= maxIndex) {
+        currentIndex = ((maxIndex + minIndex) / 2) >> 0
+        currentItem = indices[currentIndex]
+
+        if (minIndex === maxIndex) {
+            return currentItem >= left && currentItem <= right
+        } else if (currentItem < left) {
+            minIndex = currentIndex + 1
+        } else  if (currentItem > right) {
+            maxIndex = currentIndex - 1
+        } else {
+            return true
+        }
+    }
+
+    return false;
+}
+
+function ascending(a, b) {
+    return a > b ? 1 : -1
+}
+
+},{}],25:[function(require,module,exports){
+var applyProperties = require("./apply-properties")
+
+var isWidget = require("../vnode/is-widget.js")
+var VPatch = require("../vnode/vpatch.js")
+
+var updateWidget = require("./update-widget")
+
+module.exports = applyPatch
+
+function applyPatch(vpatch, domNode, renderOptions) {
+    var type = vpatch.type
+    var vNode = vpatch.vNode
+    var patch = vpatch.patch
+
+    switch (type) {
+        case VPatch.REMOVE:
+            return removeNode(domNode, vNode)
+        case VPatch.INSERT:
+            return insertNode(domNode, patch, renderOptions)
+        case VPatch.VTEXT:
+            return stringPatch(domNode, vNode, patch, renderOptions)
+        case VPatch.WIDGET:
+            return widgetPatch(domNode, vNode, patch, renderOptions)
+        case VPatch.VNODE:
+            return vNodePatch(domNode, vNode, patch, renderOptions)
+        case VPatch.ORDER:
+            reorderChildren(domNode, patch)
+            return domNode
+        case VPatch.PROPS:
+            applyProperties(domNode, patch, vNode.properties)
+            return domNode
+        case VPatch.THUNK:
+            return replaceRoot(domNode,
+                renderOptions.patch(domNode, patch, renderOptions))
+        default:
+            return domNode
+    }
+}
+
+function removeNode(domNode, vNode) {
+    var parentNode = domNode.parentNode
+
+    if (parentNode) {
+        parentNode.removeChild(domNode)
+    }
+
+    destroyWidget(domNode, vNode);
+
+    return null
+}
+
+function insertNode(parentNode, vNode, renderOptions) {
+    var newNode = renderOptions.render(vNode, renderOptions)
+
+    if (parentNode) {
+        parentNode.appendChild(newNode)
+    }
+
+    return parentNode
+}
+
+function stringPatch(domNode, leftVNode, vText, renderOptions) {
+    var newNode
+
+    if (domNode.nodeType === 3) {
+        domNode.replaceData(0, domNode.length, vText.text)
+        newNode = domNode
+    } else {
+        var parentNode = domNode.parentNode
+        newNode = renderOptions.render(vText, renderOptions)
+
+        if (parentNode && newNode !== domNode) {
+            parentNode.replaceChild(newNode, domNode)
+        }
+    }
+
+    return newNode
+}
+
+function widgetPatch(domNode, leftVNode, widget, renderOptions) {
+    var updating = updateWidget(leftVNode, widget)
+    var newNode
+
+    if (updating) {
+        newNode = widget.update(leftVNode, domNode) || domNode
+    } else {
+        newNode = renderOptions.render(widget, renderOptions)
+    }
+
+    var parentNode = domNode.parentNode
+
+    if (parentNode && newNode !== domNode) {
+        parentNode.replaceChild(newNode, domNode)
+    }
+
+    if (!updating) {
+        destroyWidget(domNode, leftVNode)
+    }
+
+    return newNode
+}
+
+function vNodePatch(domNode, leftVNode, vNode, renderOptions) {
+    var parentNode = domNode.parentNode
+    var newNode = renderOptions.render(vNode, renderOptions)
+
+    if (parentNode && newNode !== domNode) {
+        parentNode.replaceChild(newNode, domNode)
+    }
+
+    return newNode
+}
+
+function destroyWidget(domNode, w) {
+    if (typeof w.destroy === "function" && isWidget(w)) {
+        w.destroy(domNode)
+    }
+}
+
+function reorderChildren(domNode, moves) {
+    var childNodes = domNode.childNodes
+    var keyMap = {}
+    var node
+    var remove
+    var insert
+
+    for (var i = 0; i < moves.removes.length; i++) {
+        remove = moves.removes[i]
+        node = childNodes[remove.from]
+        if (remove.key) {
+            keyMap[remove.key] = node
+        }
+        domNode.removeChild(node)
+    }
+
+    var length = childNodes.length
+    for (var j = 0; j < moves.inserts.length; j++) {
+        insert = moves.inserts[j]
+        node = keyMap[insert.key]
+        // this is the weirdest bug i've ever seen in webkit
+        domNode.insertBefore(node, insert.to >= length++ ? null : childNodes[insert.to])
+    }
+}
+
+function replaceRoot(oldRoot, newRoot) {
+    if (oldRoot && newRoot && oldRoot !== newRoot && oldRoot.parentNode) {
+        oldRoot.parentNode.replaceChild(newRoot, oldRoot)
+    }
+
+    return newRoot;
+}
+
+},{"../vnode/is-widget.js":37,"../vnode/vpatch.js":40,"./apply-properties":22,"./update-widget":27}],26:[function(require,module,exports){
+var document = require("global/document")
+var isArray = require("x-is-array")
+
+var render = require("./create-element")
+var domIndex = require("./dom-index")
+var patchOp = require("./patch-op")
+module.exports = patch
+
+function patch(rootNode, patches, renderOptions) {
+    renderOptions = renderOptions || {}
+    renderOptions.patch = renderOptions.patch && renderOptions.patch !== patch
+        ? renderOptions.patch
+        : patchRecursive
+    renderOptions.render = renderOptions.render || render
+
+    return renderOptions.patch(rootNode, patches, renderOptions)
+}
+
+function patchRecursive(rootNode, patches, renderOptions) {
+    var indices = patchIndices(patches)
+
+    if (indices.length === 0) {
+        return rootNode
+    }
+
+    var index = domIndex(rootNode, patches.a, indices)
+    var ownerDocument = rootNode.ownerDocument
+
+    if (!renderOptions.document && ownerDocument !== document) {
+        renderOptions.document = ownerDocument
+    }
+
+    for (var i = 0; i < indices.length; i++) {
+        var nodeIndex = indices[i]
+        rootNode = applyPatch(rootNode,
+            index[nodeIndex],
+            patches[nodeIndex],
+            renderOptions)
+    }
+
+    return rootNode
+}
+
+function applyPatch(rootNode, domNode, patchList, renderOptions) {
+    if (!domNode) {
+        return rootNode
+    }
+
+    var newNode
+
+    if (isArray(patchList)) {
+        for (var i = 0; i < patchList.length; i++) {
+            newNode = patchOp(patchList[i], domNode, renderOptions)
+
+            if (domNode === rootNode) {
+                rootNode = newNode
+            }
+        }
+    } else {
+        newNode = patchOp(patchList, domNode, renderOptions)
+
+        if (domNode === rootNode) {
+            rootNode = newNode
+        }
+    }
+
+    return rootNode
+}
+
+function patchIndices(patches) {
+    var indices = []
+
+    for (var key in patches) {
+        if (key !== "a") {
+            indices.push(Number(key))
+        }
+    }
+
+    return indices
+}
+
+},{"./create-element":23,"./dom-index":24,"./patch-op":25,"global/document":6,"x-is-array":44}],27:[function(require,module,exports){
+var isWidget = require("../vnode/is-widget.js")
+
+module.exports = updateWidget
+
+function updateWidget(a, b) {
+    if (isWidget(a) && isWidget(b)) {
+        if ("name" in a && "name" in b) {
+            return a.id === b.id
+        } else {
+            return a.init === b.init
+        }
+    }
+
+    return false
+}
+
+},{"../vnode/is-widget.js":37}],28:[function(require,module,exports){
+'use strict';
+
+var EvStore = require('ev-store');
+
+module.exports = EvHook;
+
+function EvHook(value) {
+    if (!(this instanceof EvHook)) {
+        return new EvHook(value);
+    }
+
+    this.value = value;
+}
+
+EvHook.prototype.hook = function (node, propertyName) {
+    var es = EvStore(node);
+    var propName = propertyName.substr(3);
+
+    es[propName] = this.value;
+};
+
+EvHook.prototype.unhook = function(node, propertyName) {
+    var es = EvStore(node);
+    var propName = propertyName.substr(3);
+
+    es[propName] = undefined;
+};
+
+},{"ev-store":5}],29:[function(require,module,exports){
+'use strict';
+
+module.exports = SoftSetHook;
+
+function SoftSetHook(value) {
+    if (!(this instanceof SoftSetHook)) {
+        return new SoftSetHook(value);
+    }
+
+    this.value = value;
+}
+
+SoftSetHook.prototype.hook = function (node, propertyName) {
+    if (node[propertyName] !== this.value) {
+        node[propertyName] = this.value;
+    }
+};
+
+},{}],30:[function(require,module,exports){
+'use strict';
+
+var isArray = require('x-is-array');
+
+var VNode = require('../vnode/vnode.js');
+var VText = require('../vnode/vtext.js');
+var isVNode = require('../vnode/is-vnode');
+var isVText = require('../vnode/is-vtext');
+var isWidget = require('../vnode/is-widget');
+var isHook = require('../vnode/is-vhook');
+var isVThunk = require('../vnode/is-thunk');
+
+var parseTag = require('./parse-tag.js');
+var softSetHook = require('./hooks/soft-set-hook.js');
+var evHook = require('./hooks/ev-hook.js');
+
+module.exports = h;
+
+function h(tagName, properties, children) {
+    var childNodes = [];
+    var tag, props, key, namespace;
+
+    if (!children && isChildren(properties)) {
+        children = properties;
+        props = {};
+    }
+
+    props = props || properties || {};
+    tag = parseTag(tagName, props);
+
+    // support keys
+    if (props.hasOwnProperty('key')) {
+        key = props.key;
+        props.key = undefined;
+    }
+
+    // support namespace
+    if (props.hasOwnProperty('namespace')) {
+        namespace = props.namespace;
+        props.namespace = undefined;
+    }
+
+    // fix cursor bug
+    if (tag === 'INPUT' &&
+        !namespace &&
+        props.hasOwnProperty('value') &&
+        props.value !== undefined &&
+        !isHook(props.value)
+    ) {
+        props.value = softSetHook(props.value);
+    }
+
+    transformProperties(props);
+
+    if (children !== undefined && children !== null) {
+        addChild(children, childNodes, tag, props);
+    }
+
+
+    return new VNode(tag, props, childNodes, key, namespace);
+}
+
+function addChild(c, childNodes, tag, props) {
+    if (typeof c === 'string') {
+        childNodes.push(new VText(c));
+    } else if (typeof c === 'number') {
+        childNodes.push(new VText(String(c)));
+    } else if (isChild(c)) {
+        childNodes.push(c);
+    } else if (isArray(c)) {
+        for (var i = 0; i < c.length; i++) {
+            addChild(c[i], childNodes, tag, props);
+        }
+    } else if (c === null || c === undefined) {
+        return;
+    } else {
+        throw UnexpectedVirtualElement({
+            foreignObject: c,
+            parentVnode: {
+                tagName: tag,
+                properties: props
+            }
+        });
+    }
+}
+
+function transformProperties(props) {
+    for (var propName in props) {
+        if (props.hasOwnProperty(propName)) {
+            var value = props[propName];
+
+            if (isHook(value)) {
+                continue;
+            }
+
+            if (propName.substr(0, 3) === 'ev-') {
+                // add ev-foo support
+                props[propName] = evHook(value);
+            }
+        }
+    }
+}
+
+function isChild(x) {
+    return isVNode(x) || isVText(x) || isWidget(x) || isVThunk(x);
+}
+
+function isChildren(x) {
+    return typeof x === 'string' || isArray(x) || isChild(x);
+}
+
+function UnexpectedVirtualElement(data) {
+    var err = new Error();
+
+    err.type = 'virtual-hyperscript.unexpected.virtual-element';
+    err.message = 'Unexpected virtual child passed to h().\n' +
+        'Expected a VNode / Vthunk / VWidget / string but:\n' +
+        'got:\n' +
+        errorString(data.foreignObject) +
+        '.\n' +
+        'The parent vnode is:\n' +
+        errorString(data.parentVnode)
+        '\n' +
+        'Suggested fix: change your `h(..., [ ... ])` callsite.';
+    err.foreignObject = data.foreignObject;
+    err.parentVnode = data.parentVnode;
+
+    return err;
+}
+
+function errorString(obj) {
+    try {
+        return JSON.stringify(obj, null, '    ');
+    } catch (e) {
+        return String(obj);
+    }
+}
+
+},{"../vnode/is-thunk":33,"../vnode/is-vhook":34,"../vnode/is-vnode":35,"../vnode/is-vtext":36,"../vnode/is-widget":37,"../vnode/vnode.js":39,"../vnode/vtext.js":41,"./hooks/ev-hook.js":28,"./hooks/soft-set-hook.js":29,"./parse-tag.js":31,"x-is-array":44}],31:[function(require,module,exports){
+'use strict';
+
+var split = require('browser-split');
+
+var classIdSplit = /([\.#]?[a-zA-Z0-9\u007F-\uFFFF_:-]+)/;
+var notClassId = /^\.|#/;
+
+module.exports = parseTag;
+
+function parseTag(tag, props) {
+    if (!tag) {
+        return 'DIV';
+    }
+
+    var noId = !(props.hasOwnProperty('id'));
+
+    var tagParts = split(tag, classIdSplit);
+    var tagName = null;
+
+    if (notClassId.test(tagParts[1])) {
+        tagName = 'DIV';
+    }
+
+    var classes, part, type, i;
+
+    for (i = 0; i < tagParts.length; i++) {
+        part = tagParts[i];
+
+        if (!part) {
+            continue;
+        }
+
+        type = part.charAt(0);
+
+        if (!tagName) {
+            tagName = part;
+        } else if (type === '.') {
+            classes = classes || [];
+            classes.push(part.substring(1, part.length));
+        } else if (type === '#' && noId) {
+            props.id = part.substring(1, part.length);
+        }
+    }
+
+    if (classes) {
+        if (props.className) {
+            classes.push(props.className);
+        }
+
+        props.className = classes.join(' ');
+    }
+
+    return props.namespace ? tagName : tagName.toUpperCase();
+}
+
+},{"browser-split":4}],32:[function(require,module,exports){
+var isVNode = require("./is-vnode")
+var isVText = require("./is-vtext")
+var isWidget = require("./is-widget")
+var isThunk = require("./is-thunk")
+
+module.exports = handleThunk
+
+function handleThunk(a, b) {
+    var renderedA = a
+    var renderedB = b
+
+    if (isThunk(b)) {
+        renderedB = renderThunk(b, a)
+    }
+
+    if (isThunk(a)) {
+        renderedA = renderThunk(a, null)
+    }
+
+    return {
+        a: renderedA,
+        b: renderedB
+    }
+}
+
+function renderThunk(thunk, previous) {
+    var renderedThunk = thunk.vnode
+
+    if (!renderedThunk) {
+        renderedThunk = thunk.vnode = thunk.render(previous)
+    }
+
+    if (!(isVNode(renderedThunk) ||
+            isVText(renderedThunk) ||
+            isWidget(renderedThunk))) {
+        throw new Error("thunk did not return a valid node");
+    }
+
+    return renderedThunk
+}
+
+},{"./is-thunk":33,"./is-vnode":35,"./is-vtext":36,"./is-widget":37}],33:[function(require,module,exports){
+module.exports = isThunk
+
+function isThunk(t) {
+    return t && t.type === "Thunk"
+}
+
+},{}],34:[function(require,module,exports){
+module.exports = isHook
+
+function isHook(hook) {
+    return hook &&
+      (typeof hook.hook === "function" && !hook.hasOwnProperty("hook") ||
+       typeof hook.unhook === "function" && !hook.hasOwnProperty("unhook"))
+}
+
+},{}],35:[function(require,module,exports){
+var version = require("./version")
+
+module.exports = isVirtualNode
+
+function isVirtualNode(x) {
+    return x && x.type === "VirtualNode" && x.version === version
+}
+
+},{"./version":38}],36:[function(require,module,exports){
+var version = require("./version")
+
+module.exports = isVirtualText
+
+function isVirtualText(x) {
+    return x && x.type === "VirtualText" && x.version === version
+}
+
+},{"./version":38}],37:[function(require,module,exports){
+module.exports = isWidget
+
+function isWidget(w) {
+    return w && w.type === "Widget"
+}
+
+},{}],38:[function(require,module,exports){
+module.exports = "2"
+
+},{}],39:[function(require,module,exports){
+var version = require("./version")
+var isVNode = require("./is-vnode")
+var isWidget = require("./is-widget")
+var isThunk = require("./is-thunk")
+var isVHook = require("./is-vhook")
+
+module.exports = VirtualNode
+
+var noProperties = {}
+var noChildren = []
+
+function VirtualNode(tagName, properties, children, key, namespace) {
+    this.tagName = tagName
+    this.properties = properties || noProperties
+    this.children = children || noChildren
+    this.key = key != null ? String(key) : undefined
+    this.namespace = (typeof namespace === "string") ? namespace : null
+
+    var count = (children && children.length) || 0
+    var descendants = 0
+    var hasWidgets = false
+    var hasThunks = false
+    var descendantHooks = false
+    var hooks
+
+    for (var propName in properties) {
+        if (properties.hasOwnProperty(propName)) {
+            var property = properties[propName]
+            if (isVHook(property) && property.unhook) {
+                if (!hooks) {
+                    hooks = {}
+                }
+
+                hooks[propName] = property
+            }
+        }
+    }
+
+    for (var i = 0; i < count; i++) {
+        var child = children[i]
+        if (isVNode(child)) {
+            descendants += child.count || 0
+
+            if (!hasWidgets && child.hasWidgets) {
+                hasWidgets = true
+            }
+
+            if (!hasThunks && child.hasThunks) {
+                hasThunks = true
+            }
+
+            if (!descendantHooks && (child.hooks || child.descendantHooks)) {
+                descendantHooks = true
+            }
+        } else if (!hasWidgets && isWidget(child)) {
+            if (typeof child.destroy === "function") {
+                hasWidgets = true
+            }
+        } else if (!hasThunks && isThunk(child)) {
+            hasThunks = true;
+        }
+    }
+
+    this.count = count + descendants
+    this.hasWidgets = hasWidgets
+    this.hasThunks = hasThunks
+    this.hooks = hooks
+    this.descendantHooks = descendantHooks
+}
+
+VirtualNode.prototype.version = version
+VirtualNode.prototype.type = "VirtualNode"
+
+},{"./is-thunk":33,"./is-vhook":34,"./is-vnode":35,"./is-widget":37,"./version":38}],40:[function(require,module,exports){
+var version = require("./version")
+
+VirtualPatch.NONE = 0
+VirtualPatch.VTEXT = 1
+VirtualPatch.VNODE = 2
+VirtualPatch.WIDGET = 3
+VirtualPatch.PROPS = 4
+VirtualPatch.ORDER = 5
+VirtualPatch.INSERT = 6
+VirtualPatch.REMOVE = 7
+VirtualPatch.THUNK = 8
+
+module.exports = VirtualPatch
+
+function VirtualPatch(type, vNode, patch) {
+    this.type = Number(type)
+    this.vNode = vNode
+    this.patch = patch
+}
+
+VirtualPatch.prototype.version = version
+VirtualPatch.prototype.type = "VirtualPatch"
+
+},{"./version":38}],41:[function(require,module,exports){
+var version = require("./version")
+
+module.exports = VirtualText
+
+function VirtualText(text) {
+    this.text = String(text)
+}
+
+VirtualText.prototype.version = version
+VirtualText.prototype.type = "VirtualText"
+
+},{"./version":38}],42:[function(require,module,exports){
+var isObject = require("is-object")
+var isHook = require("../vnode/is-vhook")
+
+module.exports = diffProps
+
+function diffProps(a, b) {
+    var diff
+
+    for (var aKey in a) {
+        if (!(aKey in b)) {
+            diff = diff || {}
+            diff[aKey] = undefined
+        }
+
+        var aValue = a[aKey]
+        var bValue = b[aKey]
+
+        if (aValue === bValue) {
+            continue
+        } else if (isObject(aValue) && isObject(bValue)) {
+            if (getPrototype(bValue) !== getPrototype(aValue)) {
+                diff = diff || {}
+                diff[aKey] = bValue
+            } else if (isHook(bValue)) {
+                 diff = diff || {}
+                 diff[aKey] = bValue
+            } else {
+                var objectDiff = diffProps(aValue, bValue)
+                if (objectDiff) {
+                    diff = diff || {}
+                    diff[aKey] = objectDiff
+                }
+            }
+        } else {
+            diff = diff || {}
+            diff[aKey] = bValue
+        }
+    }
+
+    for (var bKey in b) {
+        if (!(bKey in a)) {
+            diff = diff || {}
+            diff[bKey] = b[bKey]
+        }
+    }
+
+    return diff
+}
+
+function getPrototype(value) {
+  if (Object.getPrototypeOf) {
+    return Object.getPrototypeOf(value)
+  } else if (value.__proto__) {
+    return value.__proto__
+  } else if (value.constructor) {
+    return value.constructor.prototype
+  }
+}
+
+},{"../vnode/is-vhook":34,"is-object":9}],43:[function(require,module,exports){
+var isArray = require("x-is-array")
+
+var VPatch = require("../vnode/vpatch")
+var isVNode = require("../vnode/is-vnode")
+var isVText = require("../vnode/is-vtext")
+var isWidget = require("../vnode/is-widget")
+var isThunk = require("../vnode/is-thunk")
+var handleThunk = require("../vnode/handle-thunk")
+
+var diffProps = require("./diff-props")
+
+module.exports = diff
+
+function diff(a, b) {
+    var patch = { a: a }
+    walk(a, b, patch, 0)
+    return patch
+}
+
+function walk(a, b, patch, index) {
+    if (a === b) {
+        return
+    }
+
+    var apply = patch[index]
+    var applyClear = false
+
+    if (isThunk(a) || isThunk(b)) {
+        thunks(a, b, patch, index)
+    } else if (b == null) {
+
+        // If a is a widget we will add a remove patch for it
+        // Otherwise any child widgets/hooks must be destroyed.
+        // This prevents adding two remove patches for a widget.
+        if (!isWidget(a)) {
+            clearState(a, patch, index)
+            apply = patch[index]
+        }
+
+        apply = appendPatch(apply, new VPatch(VPatch.REMOVE, a, b))
+    } else if (isVNode(b)) {
+        if (isVNode(a)) {
+            if (a.tagName === b.tagName &&
+                a.namespace === b.namespace &&
+                a.key === b.key) {
+                var propsPatch = diffProps(a.properties, b.properties)
+                if (propsPatch) {
+                    apply = appendPatch(apply,
+                        new VPatch(VPatch.PROPS, a, propsPatch))
+                }
+                apply = diffChildren(a, b, patch, apply, index)
+            } else {
+                apply = appendPatch(apply, new VPatch(VPatch.VNODE, a, b))
+                applyClear = true
+            }
+        } else {
+            apply = appendPatch(apply, new VPatch(VPatch.VNODE, a, b))
+            applyClear = true
+        }
+    } else if (isVText(b)) {
+        if (!isVText(a)) {
+            apply = appendPatch(apply, new VPatch(VPatch.VTEXT, a, b))
+            applyClear = true
+        } else if (a.text !== b.text) {
+            apply = appendPatch(apply, new VPatch(VPatch.VTEXT, a, b))
+        }
+    } else if (isWidget(b)) {
+        if (!isWidget(a)) {
+            applyClear = true
+        }
+
+        apply = appendPatch(apply, new VPatch(VPatch.WIDGET, a, b))
+    }
+
+    if (apply) {
+        patch[index] = apply
+    }
+
+    if (applyClear) {
+        clearState(a, patch, index)
+    }
+}
+
+function diffChildren(a, b, patch, apply, index) {
+    var aChildren = a.children
+    var orderedSet = reorder(aChildren, b.children)
+    var bChildren = orderedSet.children
+
+    var aLen = aChildren.length
+    var bLen = bChildren.length
+    var len = aLen > bLen ? aLen : bLen
+
+    for (var i = 0; i < len; i++) {
+        var leftNode = aChildren[i]
+        var rightNode = bChildren[i]
+        index += 1
+
+        if (!leftNode) {
+            if (rightNode) {
+                // Excess nodes in b need to be added
+                apply = appendPatch(apply,
+                    new VPatch(VPatch.INSERT, null, rightNode))
+            }
+        } else {
+            walk(leftNode, rightNode, patch, index)
+        }
+
+        if (isVNode(leftNode) && leftNode.count) {
+            index += leftNode.count
+        }
+    }
+
+    if (orderedSet.moves) {
+        // Reorder nodes last
+        apply = appendPatch(apply, new VPatch(
+            VPatch.ORDER,
+            a,
+            orderedSet.moves
+        ))
+    }
+
+    return apply
+}
+
+function clearState(vNode, patch, index) {
+    // TODO: Make this a single walk, not two
+    unhook(vNode, patch, index)
+    destroyWidgets(vNode, patch, index)
+}
+
+// Patch records for all destroyed widgets must be added because we need
+// a DOM node reference for the destroy function
+function destroyWidgets(vNode, patch, index) {
+    if (isWidget(vNode)) {
+        if (typeof vNode.destroy === "function") {
+            patch[index] = appendPatch(
+                patch[index],
+                new VPatch(VPatch.REMOVE, vNode, null)
+            )
+        }
+    } else if (isVNode(vNode) && (vNode.hasWidgets || vNode.hasThunks)) {
+        var children = vNode.children
+        var len = children.length
+        for (var i = 0; i < len; i++) {
+            var child = children[i]
+            index += 1
+
+            destroyWidgets(child, patch, index)
+
+            if (isVNode(child) && child.count) {
+                index += child.count
+            }
+        }
+    } else if (isThunk(vNode)) {
+        thunks(vNode, null, patch, index)
+    }
+}
+
+// Create a sub-patch for thunks
+function thunks(a, b, patch, index) {
+    var nodes = handleThunk(a, b)
+    var thunkPatch = diff(nodes.a, nodes.b)
+    if (hasPatches(thunkPatch)) {
+        patch[index] = new VPatch(VPatch.THUNK, null, thunkPatch)
+    }
+}
+
+function hasPatches(patch) {
+    for (var index in patch) {
+        if (index !== "a") {
+            return true
+        }
+    }
+
+    return false
+}
+
+// Execute hooks when two nodes are identical
+function unhook(vNode, patch, index) {
+    if (isVNode(vNode)) {
+        if (vNode.hooks) {
+            patch[index] = appendPatch(
+                patch[index],
+                new VPatch(
+                    VPatch.PROPS,
+                    vNode,
+                    undefinedKeys(vNode.hooks)
+                )
+            )
+        }
+
+        if (vNode.descendantHooks || vNode.hasThunks) {
+            var children = vNode.children
+            var len = children.length
+            for (var i = 0; i < len; i++) {
+                var child = children[i]
+                index += 1
+
+                unhook(child, patch, index)
+
+                if (isVNode(child) && child.count) {
+                    index += child.count
+                }
+            }
+        }
+    } else if (isThunk(vNode)) {
+        thunks(vNode, null, patch, index)
+    }
+}
+
+function undefinedKeys(obj) {
+    var result = {}
+
+    for (var key in obj) {
+        result[key] = undefined
+    }
+
+    return result
+}
+
+// List diff, naive left to right reordering
+function reorder(aChildren, bChildren) {
+    // O(M) time, O(M) memory
+    var bChildIndex = keyIndex(bChildren)
+    var bKeys = bChildIndex.keys
+    var bFree = bChildIndex.free
+
+    if (bFree.length === bChildren.length) {
+        return {
+            children: bChildren,
+            moves: null
+        }
+    }
+
+    // O(N) time, O(N) memory
+    var aChildIndex = keyIndex(aChildren)
+    var aKeys = aChildIndex.keys
+    var aFree = aChildIndex.free
+
+    if (aFree.length === aChildren.length) {
+        return {
+            children: bChildren,
+            moves: null
+        }
+    }
+
+    // O(MAX(N, M)) memory
+    var newChildren = []
+
+    var freeIndex = 0
+    var freeCount = bFree.length
+    var deletedItems = 0
+
+    // Iterate through a and match a node in b
+    // O(N) time,
+    for (var i = 0 ; i < aChildren.length; i++) {
+        var aItem = aChildren[i]
+        var itemIndex
+
+        if (aItem.key) {
+            if (bKeys.hasOwnProperty(aItem.key)) {
+                // Match up the old keys
+                itemIndex = bKeys[aItem.key]
+                newChildren.push(bChildren[itemIndex])
+
+            } else {
+                // Remove old keyed items
+                itemIndex = i - deletedItems++
+                newChildren.push(null)
+            }
+        } else {
+            // Match the item in a with the next free item in b
+            if (freeIndex < freeCount) {
+                itemIndex = bFree[freeIndex++]
+                newChildren.push(bChildren[itemIndex])
+            } else {
+                // There are no free items in b to match with
+                // the free items in a, so the extra free nodes
+                // are deleted.
+                itemIndex = i - deletedItems++
+                newChildren.push(null)
+            }
+        }
+    }
+
+    var lastFreeIndex = freeIndex >= bFree.length ?
+        bChildren.length :
+        bFree[freeIndex]
+
+    // Iterate through b and append any new keys
+    // O(M) time
+    for (var j = 0; j < bChildren.length; j++) {
+        var newItem = bChildren[j]
+
+        if (newItem.key) {
+            if (!aKeys.hasOwnProperty(newItem.key)) {
+                // Add any new keyed items
+                // We are adding new items to the end and then sorting them
+                // in place. In future we should insert new items in place.
+                newChildren.push(newItem)
+            }
+        } else if (j >= lastFreeIndex) {
+            // Add any leftover non-keyed items
+            newChildren.push(newItem)
+        }
+    }
+
+    var simulate = newChildren.slice()
+    var simulateIndex = 0
+    var removes = []
+    var inserts = []
+    var simulateItem
+
+    for (var k = 0; k < bChildren.length;) {
+        var wantedItem = bChildren[k]
+        simulateItem = simulate[simulateIndex]
+
+        // remove items
+        while (simulateItem === null && simulate.length) {
+            removes.push(remove(simulate, simulateIndex, null))
+            simulateItem = simulate[simulateIndex]
+        }
+
+        if (!simulateItem || simulateItem.key !== wantedItem.key) {
+            // if we need a key in this position...
+            if (wantedItem.key) {
+                if (simulateItem && simulateItem.key) {
+                    // if an insert doesn't put this key in place, it needs to move
+                    if (bKeys[simulateItem.key] !== k + 1) {
+                        removes.push(remove(simulate, simulateIndex, simulateItem.key))
+                        simulateItem = simulate[simulateIndex]
+                        // if the remove didn't put the wanted item in place, we need to insert it
+                        if (!simulateItem || simulateItem.key !== wantedItem.key) {
+                            inserts.push({key: wantedItem.key, to: k})
+                        }
+                        // items are matching, so skip ahead
+                        else {
+                            simulateIndex++
+                        }
+                    }
+                    else {
+                        inserts.push({key: wantedItem.key, to: k})
+                    }
+                }
+                else {
+                    inserts.push({key: wantedItem.key, to: k})
+                }
+                k++
+            }
+            // a key in simulate has no matching wanted key, remove it
+            else if (simulateItem && simulateItem.key) {
+                removes.push(remove(simulate, simulateIndex, simulateItem.key))
+            }
+        }
+        else {
+            simulateIndex++
+            k++
+        }
+    }
+
+    // remove all the remaining nodes from simulate
+    while(simulateIndex < simulate.length) {
+        simulateItem = simulate[simulateIndex]
+        removes.push(remove(simulate, simulateIndex, simulateItem && simulateItem.key))
+    }
+
+    // If the only moves we have are deletes then we can just
+    // let the delete patch remove these items.
+    if (removes.length === deletedItems && !inserts.length) {
+        return {
+            children: newChildren,
+            moves: null
+        }
+    }
+
+    return {
+        children: newChildren,
+        moves: {
+            removes: removes,
+            inserts: inserts
+        }
+    }
+}
+
+function remove(arr, index, key) {
+    arr.splice(index, 1)
+
+    return {
+        from: index,
+        key: key
+    }
+}
+
+function keyIndex(children) {
+    var keys = {}
+    var free = []
+    var length = children.length
+
+    for (var i = 0; i < length; i++) {
+        var child = children[i]
+
+        if (child.key) {
+            keys[child.key] = i
+        } else {
+            free.push(i)
+        }
+    }
+
+    return {
+        keys: keys,     // A hash of key name to index
+        free: free      // An array of unkeyed item indices
+    }
+}
+
+function appendPatch(apply, patch) {
+    if (apply) {
+        if (isArray(apply)) {
+            apply.push(patch)
+        } else {
+            apply = [apply, patch]
+        }
+
+        return apply
+    } else {
+        return patch
+    }
+}
+
+},{"../vnode/handle-thunk":32,"../vnode/is-thunk":33,"../vnode/is-vnode":35,"../vnode/is-vtext":36,"../vnode/is-widget":37,"../vnode/vpatch":40,"./diff-props":42,"x-is-array":44}],44:[function(require,module,exports){
+var nativeIsArray = Array.isArray
+var toString = Object.prototype.toString
+
+module.exports = nativeIsArray || isArray
+
+function isArray(obj) {
+    return toString.call(obj) === "[object Array]"
+}
 
 },{}]},{},[1]);

--- a/formspree/static/js/bundle.js
+++ b/formspree/static/js/bundle.js
@@ -133,9 +133,13 @@ var toastr = window.toastr;
 /* create-form validation for site-wide forms */
 module.exports = function sitewide() {
   var parentNode = $('#create-form .container');
+  if (!parentNode.length) return;
 
   var formActionURL = parentNode.find('form').attr('action');
   var currentUserEmail = parentNode.find('[name="email"]').val();
+  var emailPlaceholder = parentNode.find('[name="email"]').attr('placeholder');
+  var urlPlaceholder = parentNode.find('[name="url"]').attr('placeholder');
+  var sitewideHint = parentNode.find('label[data-hint]').data('hint');
 
   // since we have javascript, let's trash this HTML and recreate with virtual-dom
   parentNode.html('');
@@ -220,7 +224,7 @@ module.exports = function sitewide() {
     var email = _ref.email;
     var disableVerification = _ref.disableVerification;
 
-    return h('form', { method: 'post', action: formActionURL }, [h('.col-1-1', [h('h4', 'Send email to:'), h('input', { type: 'email', name: 'email', placeholder: 'You can point this form to any email address', value: email })]), h('.col-1-1', [h('h4', 'From URL:'), h('input', { type: 'url', name: 'url', placeholder: 'Leave blank to send confirmation email when first submitted' })]), h('.container', [h('.col-1-4', [h('label.hint--bottom', { dataset: { hint: 'A site-wide form is a form that you can place on all pages of your website -- and you just have to confirm once!' } }, [h('input', { type: 'checkbox', name: 'sitewide', value: 'true' }), ' site-wide'])]), h('.col-3-4', [invalid ? h('div.red', invalid === 'email' ? 'Please input a valid email address.' : ['Please input a valid URL. For example: ', h('span.code', url.resolve('http://www.mywebsite.com', sitewide ? '' : '/contact.html'))]) : sitewide && verified || !sitewide ? h('div', { innerHTML: '&#8203;' }) : h('span', ['Please ensure ', h('span.code', url.resolve(urlv, '/formspree-verify.txt')), ' exists and contains a line with ', h('span.code', email)])]), h('.col-1-3', [h('.verify', [h('button', sitewide && !invalid && !disableVerification ? {} : sitewide ? { disabled: true } : { style: { visibility: 'hidden' }, disabled: true }, 'Verify')])]), h('.col-1-3', { innerHTML: '&#8203;' }), h('.col-1-3', [h('.create', [sitewide && verified || !sitewide && !invalid ? h('button', { type: 'submit' }, 'Create form') : h('button', { disabled: true }, 'Create form')])])])]);
+    return h('form', { method: 'post', action: formActionURL }, [h('.col-1-1', [h('h4', 'Send email to:'), h('input', { type: 'email', name: 'email', placeholder: emailPlaceholder, value: email })]), h('.col-1-1', [h('h4', 'From URL:'), h('input', { type: 'url', name: 'url', placeholder: urlPlaceholder })]), h('.container', [h('.col-1-4', [h('label.hint--bottom', { dataset: { hint: sitewideHint } }, [h('input', { type: 'checkbox', name: 'sitewide', value: 'true' }), ' site-wide'])]), h('.col-3-4.info', [invalid ? h('div.red', invalid === 'email' ? 'Please input a valid email address.' : ['Please input a valid URL. For example: ', h('span.code', url.resolve('http://www.mywebsite.com', sitewide ? '' : '/contact.html'))]) : sitewide && verified || !sitewide ? h('div', { innerHTML: '&#8203;' }) : h('span', ['Please ensure ', h('span.code', url.resolve(urlv, '/formspree-verify.txt')), ' exists and contains a line with ', h('span.code', email)])]), h('.col-1-3', [h('.verify', [h('button', sitewide && !invalid && !disableVerification ? {} : sitewide ? { disabled: true } : { style: { visibility: 'hidden' }, disabled: true }, 'Verify')])]), h('.col-1-3', { innerHTML: '&#8203;' }), h('.col-1-3', [h('.create', [sitewide && verified || !sitewide && !invalid ? h('button', { type: 'submit' }, 'Create form') : h('button', { disabled: true }, 'Create form')])])])]);
   }
 };
 

--- a/formspree/static/js/bundle.js
+++ b/formspree/static/js/bundle.js
@@ -34,30 +34,39 @@ if (bgcolor.split(',').length === 4 || bgcolor === 'transparent') {
 }
 nav.css('background-color', bgcolor);
 
-/* modal */
-$('.modal').each(function () {
-  var modal = $(this);
-  modal.addClass('js');
-  var id = modal.attr('id');
-  $('[href="#' + id + '"]').click(function (e) {
-    e.preventDefault();
-    modal.toggleClass('target');
-  });
-  modal.click(function (e) {
-    if (e.target === modal[0]) {
-      modal.toggleClass('target');
+/* modals -- working with or without JS */
+function modals() {
+  $('.modal').each(function () {
+    var modal = $(this);
+    modal.addClass('js');
+    var id = modal.attr('id');
+    $('[href="#' + id + '"]').click(function (e) {
       e.preventDefault();
+      modal.toggleClass('target');
+    });
+    modal.click(function (e) {
+      if (e.target === modal[0]) {
+        modal.toggleClass('target');
+        e.preventDefault();
+      }
+    });
+    modal.find('.x a').click(function (e) {
+      e.preventDefault();
+      modal.toggleClass('target');
+    });
+  });
+
+  // activate modals from url hash #
+  setTimeout(function () {
+    // setTimeout is needed because :target elements only appear after
+    // the page is loaded or something like that.
+    var activatedModal = $('*:target');
+    if (activatedModal.length && !activatedModal.is('.target')) {
+      activatedModal.toggleClass('target');
     }
-  });
-  modal.find('.x a').click(function (e) {
-    e.preventDefault();
-    modal.toggleClass('target');
-  });
-  modal.find('.cancel').click(function (e) {
-    e.preventDefault();
-    modal.toggleClass('target')
-  });
-});
+  }, 0);
+}
+modals();
 
 /* create-form validation for site-wide forms */
 function sitewide() {

--- a/formspree/static/js/bundle.js
+++ b/formspree/static/js/bundle.js
@@ -142,7 +142,6 @@ module.exports = function sitewide() {
   var sitewideHint = parentNode.find('label[data-hint]').data('hint');
 
   // since we have javascript, let's trash this HTML and recreate with virtual-dom
-  parentNode.html('');
 
   var data = {
     invalid: null,
@@ -152,7 +151,7 @@ module.exports = function sitewide() {
   };
   var tree = render(data);
   var rootNode = createElement(tree);
-  parentNode[0].appendChild(rootNode);
+  parentNode[0].replaceChild(rootNode, parentNode.find('form')[0]);
 
   parentNode.on('change', 'input[name="sitewide"]', run);
   parentNode.on('input', 'input[name="url"], input[name="email"]', run);

--- a/formspree/static/js/main.js
+++ b/formspree/static/js/main.js
@@ -44,18 +44,29 @@ function modals () {
     modal.click(function (e) {
       // close the modal
       if (e.target === modal[0]) {
-        if (window.location.hash) window.location.hash = ''
+        cleanHash()
         modal.toggleClass('target')
         e.preventDefault()
       }
     })
     modal.find('.x a').click(function (e) {
       // close the modal
-      if (window.location.hash) window.location.hash = ''
+      cleanHash()
       e.preventDefault()
       modal.toggleClass('target')
     })
   })
+
+  function cleanHash () {
+    if (!window.location.hash) return
+    if (window.history && window.history.replaceState) {
+      window.history.replaceState('', document.title, window.location.pathname)
+    } else {
+      let pos = $(window).scrollTop()
+      window.location.hash = ''
+      $(window).scrollTop(pos)
+    }
+  }
 
   // activate modals from url hash #
   setTimeout(() => {

--- a/formspree/static/js/main.js
+++ b/formspree/static/js/main.js
@@ -1,6 +1,3 @@
-const url = require('url')
-const isValidEmail = require('is-valid-email')
-
 const $ = window.$
 const StripeCheckout = window.StripeCheckout
 const toastr = window.toastr
@@ -65,70 +62,6 @@ function modals () {
 }
 modals()
 
-/* create-form validation for site-wide forms */
-function sitewide () {
-  let createform = $('#create-form')
-  let emailInput = createform.find('input[name="email"]')
-  let urlInput = createform.find('input[name="url"]')
-  let checkbox = createform.find('input[name="sitewide"]')
-  let verifyButton = createform.find('.verify-button')
-  let createButton = createform.find('.create-button')
-  let info = createform.find('.verify-info')
-
-  checkbox.on('change', run)
-  emailInput.on('input', run)
-  urlInput.on('input', run)
-
-  function run () {
-    if (checkbox.is(':checked')) {
-      let email = emailInput.val().trim()
-      let urlp = url.parse(urlInput.val().trim())
-
-      if (isValidEmail(email) && urlp.host) {
-        let sitewideFile = `formspree_verify_${email}.txt`
-        verifyButton.css('visibility', 'visible')
-        info.html(`Please ensure <span class="code">${url.resolve(urlInput.val(), '/' + sitewideFile)}</span> exists`)
-      } else {
-        // wrong input
-        if (!urlp.host) { // invalid url
-          info.text('Please input a valid URL.')
-        } else { // invalid email
-          info.text('Please input a valid email address.')
-        }
-      }
-
-      createButton.find('button').prop('disabled', true)
-      info.css('visibility', 'visible')
-    } else {
-      // toggle sitewide off
-      info.css('visibility', 'hidden')
-      verifyButton.css('visibility', 'hidden')
-      createButton.css('visibility', 'visible')
-    }
-  }
-
-  verifyButton.find('button').on('click', function () {
-    $.ajax({
-      url: '/forms/sitewide-check?' + createform.find('form').serialize(),
-      success: function () {
-        toastr.success('The file exists! you can create your site-wide form now.')
-        createButton.find('button').prop('disabled', false)
-        verifyButton.css('visibility', 'hidden')
-        info.css('visibility', 'hidden')
-      },
-      error: function () {
-        toastr.warning("The verification file wasn't found.")
-        verifyButton.find('button').prop('disabled', true)
-        setTimeout(() => {
-          verifyButton.find('button').prop('disabled', false)
-        }, 5000)
-      }
-    })
-    return false
-  })
-}
-sitewide()
-
 /* turning flask flash messages into js popup notifications */
 window.popupMessages.forEach(function (m, i) {
   var category = m[0] || 'info'
@@ -158,3 +91,6 @@ $('a.resend').on('click', function () {
   $(this).hide()
   $('form.resend').show()
 })
+
+/* scripts at other files */
+require('./sitewide')()

--- a/formspree/static/js/main.js
+++ b/formspree/static/js/main.js
@@ -34,17 +34,24 @@ function modals () {
     let modal = $(this)
     modal.addClass('js')
     let id = modal.attr('id')
+
     $(`[href="#${id}"]`).click(function (e) {
+      // open the modal
       e.preventDefault()
       modal.toggleClass('target')
     })
+
     modal.click(function (e) {
+      // close the modal
       if (e.target === modal[0]) {
+        if (window.location.hash) window.location.hash = ''
         modal.toggleClass('target')
         e.preventDefault()
       }
     })
     modal.find('.x a').click(function (e) {
+      // close the modal
+      if (window.location.hash) window.location.hash = ''
       e.preventDefault()
       modal.toggleClass('target')
     })

--- a/formspree/static/js/main.js
+++ b/formspree/static/js/main.js
@@ -31,26 +31,39 @@ if (bgcolor.split(',').length === 4 || bgcolor === 'transparent') {
 }
 nav.css('background-color', bgcolor)
 
-/* modal */
-$('.modal').each(function () {
-  var modal = $(this)
-  modal.addClass('js')
-  var id = modal.attr('id')
-  $('[href="#' + id + '"]').click(function (e) {
-    e.preventDefault()
-    modal.toggleClass('target')
-  })
-  modal.click(function (e) {
-    if (e.target === modal[0]) {
-      modal.toggleClass('target')
+/* modals -- working with or without JS */
+function modals () {
+  $('.modal').each(function () {
+    let modal = $(this)
+    modal.addClass('js')
+    let id = modal.attr('id')
+    $(`[href="#${id}"]`).click(function (e) {
       e.preventDefault()
+      modal.toggleClass('target')
+    })
+    modal.click(function (e) {
+      if (e.target === modal[0]) {
+        modal.toggleClass('target')
+        e.preventDefault()
+      }
+    })
+    modal.find('.x a').click(function (e) {
+      e.preventDefault()
+      modal.toggleClass('target')
+    })
+  })
+
+  // activate modals from url hash #
+  setTimeout(() => {
+    // setTimeout is needed because :target elements only appear after
+    // the page is loaded or something like that.
+    let activatedModal = $('*:target')
+    if (activatedModal.length && !activatedModal.is('.target')) {
+      activatedModal.toggleClass('target')
     }
-  })
-  modal.find('.x a').click(function (e) {
-    e.preventDefault()
-    modal.toggleClass('target')
-  })
-})
+  }, 0)
+}
+modals()
 
 /* create-form validation for site-wide forms */
 function sitewide () {

--- a/formspree/static/js/sitewide.js
+++ b/formspree/static/js/sitewide.js
@@ -1,0 +1,147 @@
+const url = require('url')
+const isValidUrl = require('valid-url').isWebUri
+const isValidEmail = require('is-valid-email')
+
+const h = require('virtual-dom/h')
+const diff = require('virtual-dom/diff')
+const patch = require('virtual-dom/patch')
+const createElement = require('virtual-dom/create-element')
+
+const $ = window.$
+const toastr = window.toastr
+
+/* create-form validation for site-wide forms */
+module.exports = function sitewide () {
+  var parentNode = $('#create-form .container')
+
+  let formActionURL = parentNode.find('form').attr('action')
+  let currentUserEmail = parentNode.find('[name="email"]').val()
+
+  // since we have javascript, let's trash this HTML and recreate with virtual-dom
+  parentNode.html('')
+
+  var data = {
+    invalid: null,
+    sitewide: false,
+    verified: false,
+    email: currentUserEmail
+  }
+  var tree = render(data)
+  var rootNode = createElement(tree)
+  parentNode[0].appendChild(rootNode)
+
+  parentNode.on('change', 'input[name="sitewide"]', run)
+  parentNode.on('input', 'input[name="url"], input[name="email"]', run)
+  parentNode.on('click', '.verify button', check)
+
+  function run () {
+    let checkbox = parentNode.find('input[name="sitewide"]')
+
+    let email = parentNode.find('input[name="email"]').val().trim()
+    let urlv = parentNode.find('input[name="url"]').val().trim()
+    let sitewide = checkbox.is(':checked')
+
+    // wrong input
+    if (!isValidEmail(email)) { // invalid email
+      data.invalid = 'email'
+    } else if (sitewide && !isValidUrl(urlv)) { // invalid url with sitewide
+      data.invalid = 'url'
+    } else if (!sitewide && urlv && !isValidUrl(urlv)) { // invalid url without sitewide
+      data.invalid = 'url'
+    } else {
+      data.invalid = null
+    }
+
+    data.sitewide = sitewide
+    data.urlv = urlv
+    data.email = email
+
+    apply(render(data))
+  }
+
+  function check () {
+    $.ajax({
+      url: '/forms/sitewide-check?' + parentNode.find('form').serialize(),
+      success: function () {
+        toastr.success('The file exists! you can create your site-wide form now.')
+        data.verified = true
+        apply(render(data))
+      },
+      error: function () {
+        toastr.warning("The verification file wasn't found.")
+        data.verified = false
+        data.disableVerification = true
+        apply(render(data))
+
+        setTimeout(() => {
+          data.disableVerification = false
+          apply(render(data))
+        }, 5000)
+      }
+    })
+
+    return false
+  }
+
+  function apply (vtree) {
+    let patches = diff(tree, vtree)
+    rootNode = patch(rootNode, patches)
+    tree = vtree
+  }
+
+  function render ({invalid, sitewide, verified, urlv, email, disableVerification}) {
+    return h('form', {method: 'post', action: formActionURL}, [
+      h('.col-1-1', [
+        h('h4', 'Send email to:'),
+        h('input', {type: 'email', name: 'email', placeholder: 'You can point this form to any email address', value: email})
+      ]),
+      h('.col-1-1', [
+        h('h4', 'From URL:'),
+        h('input', {type: 'url', name: 'url', placeholder: 'Leave blank to send confirmation email when first submitted'})
+      ]),
+      h('.container', [
+        h('.col-1-4', [
+          h('label.hint--bottom', {dataset: {hint: 'A site-wide form is a form that you can place on all pages of your website -- and you just have to confirm once!'}}, [
+            h('input', {type: 'checkbox', name: 'sitewide', value: 'true'}),
+            ' site-wide'
+          ])
+        ]),
+        h('.col-3-4', [
+          invalid
+            ? h('div.red', invalid === 'email'
+              ? 'Please input a valid email address.'
+              : [
+                'Please input a valid URL. For example: ',
+                h('span.code', url.resolve('http://www.mywebsite.com', sitewide ? '' : '/contact.html'))
+              ])
+            : sitewide && verified || !sitewide
+              ? h('div', {innerHTML: '&#8203;'})
+              : h('span', [
+                'Please ensure ',
+                h('span.code', url.resolve(urlv, '/formspree-verify.txt')),
+                ' exists and contains a line with ',
+                h('span.code', email)
+              ])
+        ]),
+        h('.col-1-3', [
+          h('.verify', [
+            h('button', sitewide && !invalid && !disableVerification
+              ? {}
+              : sitewide
+                ? {disabled: true}
+                : {style: {visibility: 'hidden'}, disabled: true},
+            'Verify')
+          ])
+        ]),
+        h('.col-1-3', {innerHTML: '&#8203;'}),
+        h('.col-1-3', [
+          h('.create', [
+            sitewide && verified || !sitewide && !invalid
+              ? h('button', {type: 'submit'}, 'Create form')
+              : h('button', {disabled: true}, 'Create form')
+          ])
+        ])
+      ])
+    ])
+  }
+}

--- a/formspree/static/js/sitewide.js
+++ b/formspree/static/js/sitewide.js
@@ -42,6 +42,7 @@ module.exports = function sitewide () {
 
     let email = parentNode.find('input[name="email"]').val().trim()
     let urlv = parentNode.find('input[name="url"]').val().trim()
+    urlv = /^https?:\/\//.test(urlv) ? urlv : 'http://' + urlv
     let sitewide = checkbox.is(':checked')
 
     // wrong input
@@ -100,7 +101,7 @@ module.exports = function sitewide () {
       ]),
       h('.col-1-1', [
         h('h4', 'From URL:'),
-        h('input', {type: 'url', name: 'url', placeholder: urlPlaceholder})
+        h('input', {type: 'text', name: 'url', placeholder: urlPlaceholder})
       ]),
       h('.container', [
         h('.col-1-4', [

--- a/formspree/static/js/sitewide.js
+++ b/formspree/static/js/sitewide.js
@@ -22,7 +22,6 @@ module.exports = function sitewide () {
   let sitewideHint = parentNode.find('label[data-hint]').data('hint')
 
   // since we have javascript, let's trash this HTML and recreate with virtual-dom
-  parentNode.html('')
 
   var data = {
     invalid: null,
@@ -32,7 +31,7 @@ module.exports = function sitewide () {
   }
   var tree = render(data)
   var rootNode = createElement(tree)
-  parentNode[0].appendChild(rootNode)
+  parentNode[0].replaceChild(rootNode, parentNode.find('form')[0])
 
   parentNode.on('change', 'input[name="sitewide"]', run)
   parentNode.on('input', 'input[name="url"], input[name="email"]', run)

--- a/formspree/static/js/sitewide.js
+++ b/formspree/static/js/sitewide.js
@@ -13,9 +13,13 @@ const toastr = window.toastr
 /* create-form validation for site-wide forms */
 module.exports = function sitewide () {
   var parentNode = $('#create-form .container')
+  if (!parentNode.length) return
 
   let formActionURL = parentNode.find('form').attr('action')
   let currentUserEmail = parentNode.find('[name="email"]').val()
+  let emailPlaceholder = parentNode.find('[name="email"]').attr('placeholder')
+  let urlPlaceholder = parentNode.find('[name="url"]').attr('placeholder')
+  let sitewideHint = parentNode.find('label[data-hint]').data('hint')
 
   // since we have javascript, let's trash this HTML and recreate with virtual-dom
   parentNode.html('')
@@ -93,20 +97,20 @@ module.exports = function sitewide () {
     return h('form', {method: 'post', action: formActionURL}, [
       h('.col-1-1', [
         h('h4', 'Send email to:'),
-        h('input', {type: 'email', name: 'email', placeholder: 'You can point this form to any email address', value: email})
+        h('input', {type: 'email', name: 'email', placeholder: emailPlaceholder, value: email})
       ]),
       h('.col-1-1', [
         h('h4', 'From URL:'),
-        h('input', {type: 'url', name: 'url', placeholder: 'Leave blank to send confirmation email when first submitted'})
+        h('input', {type: 'url', name: 'url', placeholder: urlPlaceholder})
       ]),
       h('.container', [
         h('.col-1-4', [
-          h('label.hint--bottom', {dataset: {hint: 'A site-wide form is a form that you can place on all pages of your website -- and you just have to confirm once!'}}, [
+          h('label.hint--bottom', {dataset: {hint: sitewideHint}}, [
             h('input', {type: 'checkbox', name: 'sitewide', value: 'true'}),
             ' site-wide'
           ])
         ]),
-        h('.col-3-4', [
+        h('.col-3-4.info', [
           invalid
             ? h('div.red', invalid === 'email'
               ? 'Please input a valid email address.'

--- a/formspree/static/scss/dashboard.scss
+++ b/formspree/static/scss/dashboard.scss
@@ -113,8 +113,10 @@
       text-align: center;
     }
 
-    .verify-info {
+    .info {
       font-size: 13px;
+      margin-bottom: 10px;
+      text-align: right;
     }
   
     .modal:not(.js):target > *,
@@ -186,7 +188,6 @@
       display: block;
     }
 
-    .small { text-size: 80%; }
     .red { color: $red; }
   }
 }

--- a/formspree/static/scss/dashboard.scss
+++ b/formspree/static/scss/dashboard.scss
@@ -80,7 +80,6 @@
       tr.waiting_confirmation span[class^="ion-"] { color: $warning-orange }
       tr.new span[class^="ion-"] { color: $red }
       tr.new a:not(*:hover) {
-        color: inherit;
         display: block;
         border-bottom: 1px dotted;
         float: left;
@@ -88,6 +87,9 @@
         line-height: 1em;
       }
       tr.new .never { font-size: 15px; }
+      tr:not(.new) *:not(.n-submissions) a:not(*:hover) {
+        color: inherit;
+      }
     }
   
     &.emails tr:nth-child(2) td {

--- a/formspree/static/scss/dashboard.scss
+++ b/formspree/static/scss/dashboard.scss
@@ -68,10 +68,17 @@
   
     &.forms,
     &.emails {
+      tr { height: 39px; }
+
+      td.target-email {
+        max-width: 250px;
+        word-break: break-word;
+      }
+      td.n-submissions { min-width: 150px; }
+
       tr.verified span[class^="ion-"] { color: $dark-green }
-      tr.new span[class^="ion-"] { color: $red}
       tr.waiting_confirmation span[class^="ion-"] { color: $warning-orange }
-  
+      tr.new span[class^="ion-"] { color: $red }
       tr.new a:not(*:hover) {
         color: inherit;
         display: block;
@@ -80,6 +87,7 @@
         margin-bottom: -1px;
         line-height: 1em;
       }
+      tr.new .never { font-size: 15px; }
     }
   
     &.emails tr:nth-child(2) td {
@@ -115,7 +123,7 @@
     }
   }
   
-  .modal[id^="view-code"] {
+  .modal[id^="form-"] {
     textarea {
       font-size: 15px;
     }
@@ -151,9 +159,7 @@
         margin: 0;
         padding: 0;
         margin-top: 13px;
-      }
-      textarea {
-        min-height: 149px;
+        float: left;
       }
     }
     &:not(.js):target > *,
@@ -179,7 +185,8 @@
     &.target:before {
       display: block;
     }
+
+    .small { text-size: 80%; }
+    .red { color: $red; }
   }
 }
-
-.red { color: $color; }

--- a/formspree/static/scss/dashboard.scss
+++ b/formspree/static/scss/dashboard.scss
@@ -87,9 +87,7 @@
       tr.verified span[class^="ion-"] { color: $dark-green }
 
       tr.new a:not(*:hover) {
-        display: block;
         border-bottom: 1px dotted;
-        float: left;
         margin-bottom: -1px;
         line-height: 1em;
       }
@@ -206,10 +204,6 @@
   }
   .fa-lock:hover::before {
     content: "\f09c";
-  }
-  .fa-trash-o:hover::before,
-  .fa-trash:hover::before {
-    content: "\f071";
   }
 }
 

--- a/formspree/static/scss/dashboard.scss
+++ b/formspree/static/scss/dashboard.scss
@@ -36,13 +36,13 @@
   }
 
   .delete {
-    color: #D9534F;
-    border-color: #D9534F;
+    color: $red;
+    border-color: $red;
   }
 
   .delete:hover {
     transition: color 0.3s ease-in-out;
-    color: #d1332e;
+    color: $warning-orange;
   }
 
   table {

--- a/formspree/static/scss/dashboard.scss
+++ b/formspree/static/scss/dashboard.scss
@@ -191,3 +191,19 @@
     .red { color: $red; }
   }
 }
+
+.html-highlight {
+  clear: both;
+  font-size: 14px;
+  font-family: monospace;
+  padding: 5px;
+  border: 2px dashed #696969;
+  border-radius: 5px;
+
+  .bracket { color: #a65700 }
+  .tagname { color: #800000; font-weight: bold; }
+  .attrkey { color: #074726 }
+  .equal { color: #808030 }
+  .attrvalue { color: #0000e6 }
+  .comment { color: #696969 }
+}

--- a/formspree/static/scss/dashboard.scss
+++ b/formspree/static/scss/dashboard.scss
@@ -21,6 +21,12 @@
   border-bottom: none !important;
 }
 
+.no-border {
+  border: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
 .dashboard {
   .row:after {
     content: "";
@@ -192,6 +198,18 @@
     }
 
     .red { color: $red; }
+  }
+
+  /* icon morphing */
+  .fa-unlock:hover::before {
+    content: "\f023";
+  }
+  .fa-lock:hover::before {
+    content: "\f09c";
+  }
+  .fa-trash-o:hover::before,
+  .fa-trash:hover::before {
+    content: "\f071";
   }
 }
 

--- a/formspree/static/scss/dashboard.scss
+++ b/formspree/static/scss/dashboard.scss
@@ -181,3 +181,5 @@
     }
   }
 }
+
+.red { color: $color; }

--- a/formspree/static/scss/dashboard.scss
+++ b/formspree/static/scss/dashboard.scss
@@ -76,9 +76,10 @@
       }
       td.n-submissions { min-width: 150px; }
 
-      tr.verified span[class^="ion-"] { color: $dark-green }
-      tr.waiting_confirmation span[class^="ion-"] { color: $warning-orange }
       tr.new span[class^="ion-"] { color: $red }
+      tr.waiting_confirmation span[class^="ion-"] { color: $warning-orange }
+      tr.verified span[class^="ion-"] { color: $dark-green }
+
       tr.new a:not(*:hover) {
         display: block;
         border-bottom: 1px dotted;

--- a/formspree/static/scss/main.scss
+++ b/formspree/static/scss/main.scss
@@ -6,7 +6,7 @@ $dark-blue: #1b3544;
 $accent-blue: #f1f1fa;
 $accent: #ddd;
 
-$red: #ff1708;
+$red: #D9534F;
 $green: #359173;
 
 $warning-orange: #D87431;

--- a/formspree/templates/forms/create.html
+++ b/formspree/templates/forms/create.html
@@ -7,7 +7,7 @@
   
     <div class="modal" id="create-form" aria-hidden="true">
       <div class="container">
-        <div class="x"><a href="#">&times;</a></div>
+        <div class="x"><h4>Create form</h4><a href="#">&times;</a></div>
         <form method="POST" action="{{ url_for('create-form') }}">
           <div class="col-1-1">
             <h4>Send email to:</h4>

--- a/formspree/templates/forms/create.html
+++ b/formspree/templates/forms/create.html
@@ -24,15 +24,12 @@
                 site-wide
               </label>
             </div>
-            <div class="col-3-4">
-              <div class="verify-info" style="visibility: hidden"></div>
-              <noscript>
-                When creating a form that is valid site-wide, ensure you have a file at the root of your site that matches the pattern <span class="code">/formspree_verify_emailaddress@provider.com</span>
-              </noscript>
+            <div class="col-3-4 info">
+              When creating a form that is valid site-wide, ensure you have a file named <span class="code">/formspree-verify.txt</span> at the root of your site and that it contains a line with the target email inside.
             </div>
           </div>
           <div class="col-1-3">
-            <div class="verify-button" style="visibility: hidden">
+            <div class="verify">
               <button>Verify</button>
             </div>
           </div>
@@ -40,7 +37,7 @@
             &#8203;
           </div>
           <div class="col-1-3">
-            <div class="create-button">
+            <div class="create">
               <button type="submit">Create form</button>
             </div>
           </div>
@@ -48,7 +45,7 @@
       </div>
     </div>
   {% else %}
-    <h6 class="light">Please <a href="{{ url_for('account') }}">upgrade</a> your account in order to create forms from the dashboard and manage the forms currently associated with your emails.</h6>
+    <h6 class="light">Please <a href="{{ url_for('account') }}">upgrade your account</a> in order to create forms from the dashboard and manage the forms currently associated with your emails.</h6>
   {% endif %}
   </div>
 </div>

--- a/formspree/templates/forms/list-item.html
+++ b/formspree/templates/forms/list-item.html
@@ -1,0 +1,35 @@
+<tr class="{% if form.is_new %}new{% elif form.confirmed %}verified{% elif form.confirm_sent %}waiting_confirmation{% endif %}">
+  <td>
+    <a href="#form-{{ form.hashid }}" class="no-underline">
+    {% if form.is_new %}
+      <span class="tooltip hint--right" data-hint="New form. Place the code generated here in some page and submit it!"><span class="ion-help"></span></span>
+    {% elif form.confirmed %}
+      <span class="tooltip hint--right" data-hint="Form confirmed"><span class="ion-checkmark-round"></span></span>
+    {% elif form.confirm_sent %}
+      <span class="tooltip hint--right" data-hint="Waiting confirmation"><span class="ion-pause"></span></span>
+    {% endif %}
+    </a>
+  </td>
+  <td>
+    {% if form.is_new %}
+      <a href="#form-{{ form.hashid }}">View HTML code</a>
+    {% else %}
+      {{ form.host }}
+      {% if form.sitewide %}
+        <span class="highlight tooltip hint--top" data-hint="This form works for all paths under {{ form.host }}/">/ *</span>
+      {% endif %}
+    {% endif %}
+  </td>
+  <td class="target-email"><span class="hint--top" data-hint="{{ request.url_root.replace('http://', 'https://') }}{% if form.hash %}{{ form.email }}{% else %}{{ form.hashid }}{% endif %}">{{ form.email }}</span></td>
+  <td class="n-submissions">
+    {% if form.is_new %}
+      <span class="never">never submitted</span>
+    {% else %}
+      <a href="{{ url_for('form-submissions', hashid=form.hashid) }}">{{ form.counter }} submissions</a>
+    {% endif %}
+  </td>
+    <td><form method="POST" action="{{ url_for('form-toggle') }}"><input type="hidden" name="hashid" value="{{form.hashid}}"><button class="submit" class="no-border" style="border:none;padding:0;"><i class="fa fa-unlock"></i></button></form></td>
+	<td>
+	<a href="#delete-{{form.hashid}}" class="no-underline"><i class="fa fa-trash-o delete"></i></a>
+	</td>
+</tr>

--- a/formspree/templates/forms/list-item.html
+++ b/formspree/templates/forms/list-item.html
@@ -1,7 +1,7 @@
-<tr class="{% if form.is_new %}new{% elif form.confirmed %}verified{% elif form.confirm_sent %}waiting_confirmation{% endif %}">
+<tr class="{% if form.counter == 0 %}new{% endif %} {% if form.confirmed %}verified{% elif form.confirm_sent %}waiting_confirmation{% endif %}">
   <td>
     <a href="#form-{{ form.hashid }}" class="no-underline">
-    {% if form.is_new %}
+    {% if not form.host %}
       <span class="tooltip hint--right" data-hint="New form. Place the code generated here in some page and submit it!"><span class="ion-help"></span></span>
     {% elif form.confirmed %}
       <span class="tooltip hint--right" data-hint="Form confirmed"><span class="ion-checkmark-round"></span></span>
@@ -12,7 +12,7 @@
   </td>
   <td>
     <a href="#form-{{ form.hashid }}" class="no-underline">
-    {% if form.is_new %}
+    {% if not form.host %}
       Waiting for a submission
     {% else %}
       {{ form.host }}
@@ -29,7 +29,7 @@
   </td>
   <td class="n-submissions">
     <a href="{{ url_for('form-submissions', hashid=form.hashid) }}" class="no-underline">
-    {% if form.is_new %}
+    {% if form.counter == 0 %}
       <span class="never">never submitted</span>
     {% else %}
       {{ form.counter }} submissions

--- a/formspree/templates/forms/list-item.html
+++ b/formspree/templates/forms/list-item.html
@@ -36,7 +36,7 @@
     {% endif %}
     </a>
   </td>
-    <td><form method="POST" action="{{ url_for('form-toggle', hashid=form.hashid) }}"><button class="no-border"><i class="fa fa-{% if form.disabled %}lock{% else %}unlock{% endif %}"></i></button></form></td>
+    <td><form method="POST" action="{{ url_for('form-toggle', hashid=form.hashid) }}"><button class="no-border"><i class="fa fa-{% if form.disabled %}lock{% else %}unlock{% endif %} fa-fw"></i></button></form></td>
 	<td>
 	<a href="#delete-{{form.hashid}}" class="no-underline"><i class="fa fa-trash-o delete"></i></a>
 	</td>

--- a/formspree/templates/forms/list-item.html
+++ b/formspree/templates/forms/list-item.html
@@ -36,7 +36,7 @@
     {% endif %}
     </a>
   </td>
-    <td><form method="POST" action="{{ url_for('form-toggle') }}"><input type="hidden" name="hashid" value="{{form.hashid}}"><button class="submit" class="no-border" style="border:none;padding:0;"><i class="fa fa-unlock"></i></button></form></td>
+    <td><form method="POST" action="{{ url_for('form-toggle', hashid=form.hashid) }}"><button class="no-border"><i class="fa fa-{% if form.disabled %}lock{% else %}unlock{% endif %}"></i></button></form></td>
 	<td>
 	<a href="#delete-{{form.hashid}}" class="no-underline"><i class="fa fa-trash-o delete"></i></a>
 	</td>

--- a/formspree/templates/forms/list-item.html
+++ b/formspree/templates/forms/list-item.html
@@ -11,22 +11,30 @@
     </a>
   </td>
   <td>
+    <a href="#form-{{ form.hashid }}" class="no-underline">
     {% if form.is_new %}
-      <a href="#form-{{ form.hashid }}">View HTML code</a>
+      Waiting for a submission
     {% else %}
       {{ form.host }}
       {% if form.sitewide %}
         <span class="highlight tooltip hint--top" data-hint="This form works for all paths under {{ form.host }}/">/ *</span>
       {% endif %}
     {% endif %}
+    </a>
   </td>
-  <td class="target-email"><span class="hint--top" data-hint="{{ request.url_root.replace('http://', 'https://') }}{% if form.hash %}{{ form.email }}{% else %}{{ form.hashid }}{% endif %}">{{ form.email }}</span></td>
+  <td class="target-email">
+    <a href="#form-{{ form.hashid }}" class="no-underline">
+      <span class="hint--top" data-hint="{{ request.url_root.replace('http://', 'https://') }}{% if form.hash %}{{ form.email }}{% else %}{{ form.hashid }}{% endif %}">{{ form.email }}</span>
+    </a>
+  </td>
   <td class="n-submissions">
+    <a href="{{ url_for('form-submissions', hashid=form.hashid) }}" class="no-underline">
     {% if form.is_new %}
       <span class="never">never submitted</span>
     {% else %}
-      <a href="{{ url_for('form-submissions', hashid=form.hashid) }}">{{ form.counter }} submissions</a>
+      {{ form.counter }} submissions
     {% endif %}
+    </a>
   </td>
     <td><form method="POST" action="{{ url_for('form-toggle') }}"><input type="hidden" name="hashid" value="{{form.hashid}}"><button class="submit" class="no-border" style="border:none;padding:0;"><i class="fa fa-unlock"></i></button></form></td>
 	<td>

--- a/formspree/templates/forms/list.html
+++ b/formspree/templates/forms/list.html
@@ -38,7 +38,12 @@
 {% for form in (enabled_forms + disabled_forms) %}
   <div class="modal" id="form-{{ form.hashid }}" aria-hidden="true">
     <div>
-      <div class="x"><h4>Use this code in your HTML</h4><a href="#">&times;</a></div>
+      {% if request.args.get('new') == form.hashid %}
+        <div class="x"><h4>Congratulations!</h4><a href="#">&times;</a></div>
+        <p style="clear: both">Now that you have created your form, use the following HTML code in your website, filling it with the input fields you wish your visitors to input:</p>
+      {% else %}
+        <div class="x"><h4>Use this code in your HTML</h4><a href="#">&times;</a></div>
+      {% endif %}
       <div class="html-highlight">
         <span class="bracket">&lt;</span><span class="tagname">form</span>
         <span class="attrkey">action</span><span class="equal">=</span><span class="attrvalue">{{ config.SERVICE_URL }}/gpbwkobj"</span>

--- a/formspree/templates/forms/list.html
+++ b/formspree/templates/forms/list.html
@@ -71,9 +71,8 @@
         <div class="x"><h4>Are you ABSOLUTELY sure?</h4><a href="#">&times;</a></div>
       <br />
       <p>This action <strong>CANNOT</strong> be undone. This will permanantly delete the form{% if form.host %} on <strong>{{form.host}}</strong>{% endif %} and all related submissions.</p>
-        <form method="POST" action="{{ url_for('form-deletion') }}">
-          <input type="hidden" name="hashid" value="{{ form.hashid }}">
-            <span class="cancel"><button type="button" onclick="return false;">Cancel</button></span>
+        <form method="POST" action="{{ url_for('form-deletion', hashid=form.hashid) }}">
+          <span class="cancel"><button type="button" onclick="return false;">Cancel</button></span>
           <button class="delete">Confirm deletion</button>
         </form>
     </div>

--- a/formspree/templates/forms/list.html
+++ b/formspree/templates/forms/list.html
@@ -9,108 +9,45 @@
 <div class="col-1-1">
   <h4>Active Forms</h4>
   <table class="forms">
-  {# status icon | host or view-code link | target email | number of submissions #}
-  {% for form in forms if not form.disabled or form.disabled is not defined %}
-    <tr class="{% if form.is_new %}new{% elif form.confirmed %}verified{% elif form.confirm_sent %}waiting_confirmation{% endif %}">
-      <td>
-      {% if form.is_new %}
-        <span class="tooltip hint--right" data-hint="New form. Place the code generated here in some page and submit it!"><span class="ion-help"></span></span>
-      {% elif form.confirmed %}
-        <span class="tooltip hint--right" data-hint="Confirmed form"><span class="ion-checkmark-round"></span></span>
-      {% elif form.confirm_sent %}
-        <span class="tooltip hint--right" data-hint="Waiting confirmation"><span class="ion-pause"></span></span>
-      {% endif %}
-      </td>
-      <td>
-        {% if form.is_new %}
-          <a href="#view-code-{{ form.hashid }}">View HTML code</a>
-        {% else %}
-          {{ form.host }}
-          {% if form.sitewide %}
-            <span class="highlight tooltip hint--top" data-hint="This form works for all paths under {{ form.host }}/">/ *</span>
-          {% endif %}
-        {% endif %}
-      </td>
-      <td><span class="hint--top" data-hint="{{ request.url_root.replace('http://', 'https://') }}{% if form.hash %}{{ form.email }}{% else %}{{ form.hashid }}{% endif %}">{{ form.email }}</span></td>
-      <td>
-        {% if form.is_new %}
-          form never submitted
-        {% else %}
-          <a href="{{ url_for('form-submissions', hashid=form.hashid) }}">{{ form.counter }} submissions</a>
-        {% endif %}
-      </td>
-        <td><form method="POST" action="{{ url_for('form-toggle') }}"><input type="hidden" name="hashid" value="{{form.hashid}}"><button class="submit" class="no-border" style="border:none;padding:0;"><i class="fa fa-lock"></i></button></form></td>
-		<td>
-		<a href="#delete-{{form.hashid}}" class="no-underline"><i class="fa fa-trash-o delete"></i></a>
-		</td>
-    </tr>
+  {# status icon | host or form link | target email | number of submissions #}
+  {% for form in enabled_forms %}
+    {% include "forms/list-item.html" %}
   {% else %}
-      <p>No active forms found. Forms can be enabled by clicking the unlock icon below.</p>
+    <p>No active forms found. Forms can be enabled by clicking the unlock icon below.</p>
   {% endfor %}
   </table>
 
-  <h4>Disabled Forms</h4>
-  <table class="forms">
-  {# status icon | host or view-code link | target email | number of submissions #}
-  {% for form in forms if form.disabled %}
-    <tr class="{% if form.is_new %}new{% elif form.confirmed %}verified{% elif form.confirm_sent %}waiting_confirmation{% endif %}">
-      <td>
-      {% if form.is_new %}
-        <span class="tooltip hint--right" data-hint="New form. Place the code generated here in some page and submit it!"><span class="ion-help"></span></span>
-      {% elif form.confirmed %}
-        <span class="tooltip hint--right" data-hint="Confirmed form"><span class="ion-checkmark-round"></span></span>
-      {% elif form.confirm_sent %}
-        <span class="tooltip hint--right" data-hint="Waiting confirmation"><span class="ion-pause"></span></span>
-      {% endif %}
-      </td>
-      <td>
-        {% if form.is_new %}
-          <a href="#view-code-{{ form.hashid }}">View HTML code</a>
-        {% else %}
-          {{ form.host }}
-        {% endif %}
-      </td>
-      <td><span class="hint--top" data-hint="{{ request.url_root.replace('http://', 'https://') }}{% if form.hash %}{{ form.email }}{% else %}{{ form.hashid }}{% endif %}">{{ form.email }}</span></td>
-      <td>
-        {% if form.is_new %}
-          form never submitted
-        {% else %}
-          <a href="{{ url_for('form-submissions', hashid=form.hashid) }}">{{ form.counter }} submissions</a>
-        {% endif %}
-      </td>
-        <td><form method="POST" action="{{ url_for('form-toggle') }}"><input type="hidden" name="hashid" value="{{form.hashid}}"><button class="submit" class="no-border" style="border:none;padding:0;"><i class="fa fa-unlock"></i></button></form></td>
-		<td>
-		<a href="#delete-{{form.hashid}}" class="no-underline"><i class="fa fa-trash-o delete"></i></a>
-		</td>
-    </tr>
-  {% else %}
-      <p>No disabled forms found. Forms can be disabled by clicking the lock next to a form.</p>
-  {% endfor %}
-  </table>
+  {% if disabled_forms %}
+    <h4>Disabled Forms</h4>
+    <table class="forms">
+    {# status icon | host or form link | target email | number of submissions #}
+    {% for form in disabled_forms %}
+      {% include "forms/list-item.html" %}
+    {% endfor %}
+    </table>
+  {% endif %}
 
-
-
-  {% if not forms and current_user.upgraded %}
+  {% if not enabled_forms and not disabled_forms and current_user.upgraded %}
     <h6 class="light">You don't have any forms associated with this account, maybe you should <a href="{{ url_for('account') }}">verify your email</a>.</h6>
   {% endif %}
 </div>
 
 {% include "forms/create.html" %}
 
-
 {# "view HTML code" modals for each form #}
 {% macro showcode(form) %}{% set formcode %}<form action="{{ form.action }}" method="POST">
-  <input type="text" name="_gotcha" style="display: none" />
-  <input type="email" name="email" placeholder="Your email">
-  <textarea name="message" rows="5" placeholder="Your message"></textarea>
-  <input type="submit" value="Send">
+  <input type=text name=_gotcha style="display: none">
+
+  <!-- your other form fields go here -->
+
+  <button type=submit>Send</button>
 </form>{% endset %}{{ formcode|escape }}{%- endmacro %}
 
-{% for form in forms %}
-  <div class="modal" id="view-code-{{ form.hashid }}" aria-hidden="true">
+{% for form in (enabled_forms + disabled_forms) %}
+  <div class="modal" id="form-{{ form.hashid }}" aria-hidden="true">
     <div>
-      <div class="x"><h4>Place this code in your page's HTML</h4><a href="#">&times;</a></div>
-      <textarea rows="7">{{ showcode(form) }}</textarea>
+      <div class="x"><h4>Use this code in your HTML</h4><a href="#">&times;</a></div>
+      <textarea rows="8">{{ showcode(form) }}</textarea>
     </div>
   </div>
 
@@ -122,7 +59,7 @@
         <form method="POST" action="{{ url_for('form-deletion') }}">
           <input type="hidden" name="hashid" value="{{ form.hashid }}">
             <span class="cancel"><button type="button" onclick="return false;">Cancel</button></span>
-          <button class="delete">Confirm Deletion</button>
+          <button class="delete">Confirm deletion</button>
         </form>
     </div>
   </div>

--- a/formspree/templates/forms/list.html
+++ b/formspree/templates/forms/list.html
@@ -34,20 +34,30 @@
 
 {% include "forms/create.html" %}
 
-{# "view HTML code" modals for each form #}
-{% macro showcode(form) %}{% set formcode %}<form action="{{ form.action }}" method="POST">
-  <input type=text name=_gotcha style="display: none">
-
-  <!-- your other form fields go here -->
-
-  <button type=submit>Send</button>
-</form>{% endset %}{{ formcode|escape }}{%- endmacro %}
-
+{# modals for each form #}
 {% for form in (enabled_forms + disabled_forms) %}
   <div class="modal" id="form-{{ form.hashid }}" aria-hidden="true">
     <div>
       <div class="x"><h4>Use this code in your HTML</h4><a href="#">&times;</a></div>
-      <textarea rows="8">{{ showcode(form) }}</textarea>
+      <div class="html-highlight">
+        <span class="bracket">&lt;</span><span class="tagname">form</span>
+        <span class="attrkey">action</span><span class="equal">=</span><span class="attrvalue">{{ config.SERVICE_URL }}/gpbwkobj"</span>
+        <span class="attrkey">method</span><span class="equal">=</span><span class="attrvalue">"POST"</span><span class="bracket">></span>
+        <br>
+        &nbsp;&nbsp;<span class="bracket">&lt;</span><span class="tagname">input</span>
+        <span class="attrkey">type</span><span class="equal">=</span><span class="attrvalue">"text"</span>
+        <span class="attrkey">name</span><span class="equal">=</span><span class="attrvalue">"_gotcha"</span>
+        <span class="attrkey">style</span><span class="equal">=</span><span class="attrvalue">"display: none"</span><span class="bracket">></span>
+        <br>
+        <br>
+        &nbsp;&nbsp;<span class="comment">&lt;!-- your other form fields go here --></span>
+        <br>
+        <br>
+        &nbsp;&nbsp;<span class="bracket">&lt;</span><span class="tagname">button</span>
+        <span class="attrkey">type</span><span class="equal">=</span><span class="attrvalue">"submit"</span><span class="bracket">></span>Send<span class="bracket">&lt;/</span><span class="tagname">button</span><span class="bracket">></span>
+        <br>
+        <span class="bracket">&lt;/</span><span class="tagname">form</span><span class="bracket">></span>
+      </div>
     </div>
   </div>
 

--- a/formspree/templates/forms/list.html
+++ b/formspree/templates/forms/list.html
@@ -40,7 +40,7 @@
     <div>
       {% if request.args.get('new') == form.hashid %}
         <div class="x"><h4>Congratulations!</h4><a href="#">&times;</a></div>
-        <p style="clear: both">Now that you have created your form, use the following HTML code in your website, filling it with the input fields you wish your visitors to input:</p>
+        <p style="clear: both">Now that you have created your form, use the following HTML code in your website, filling it with the <span class="code">&lt;input&gt;</span> fields you wish your visitors to fill:</p>
       {% else %}
         <div class="x"><h4>Use this code in your HTML</h4><a href="#">&times;</a></div>
       {% endif %}

--- a/formspree/templates/forms/submissions.html
+++ b/formspree/templates/forms/submissions.html
@@ -38,7 +38,7 @@
               {% for f in fields %}
                 <td><pre>{{ submission.data[f] }}</pre></td>
               {% endfor %}
-                <td><form method="POST" action="{{ url_for('submission-deletion', hashid=form.hashid) }}"><input type="hidden" name="submissionid" value="{{submission.id}}"><button class="submit" class="no-border" style="border:none;padding:0;"><i class="fa fa-trash-o delete"></i></button></form></td>
+                <td><form method="POST" action="{{ url_for('submission-deletion', hashid=form.hashid, submissionid=submission.id) }}"><button class="no-border"><i class="fa fa-trash-o delete"></i></button></form></td>
 <!--			<td><a href="{{ url_for('submission-deletion', hashid=form.hashid, submissionid=submission.id) }}" class="no-underline"><i class="fa fa-trash-o delete"></i></a></td>-->
             </tr>
           {% endfor %}

--- a/manage.py
+++ b/manage.py
@@ -23,7 +23,7 @@ manager.add_command('db', MigrateCommand)
 
 
 @manager.command
-def run_debug(port=5000):
+def run_debug(port=os.getenv('PORT', 5000)):
     '''runs the app with debug flag set to true'''
     forms_app.run(host='0.0.0.0', debug=True, port=int(port))
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   },
   "dependencies": {
     "is-valid-email": "0.0.2",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "valid-url": "^1.0.9",
+    "virtual-dom": "^2.1.1"
   },
   "devDependencies": {
     "babel-core": "^6.6.5",

--- a/tests/test_form_creation.py
+++ b/tests/test_form_creation.py
@@ -151,10 +151,12 @@ class TestFormCreationFromDashboard(FormspreeTestCase):
     @httpretty.activate
     def test_sitewide_forms(self):
         httpretty.register_uri(httpretty.GET,
-                               'http://mysite.com/formspree_verify_myemail@email.com.txt',
+                               'http://mysite.com/formspree-verify.txt',
+                               body='other_email@forms.com\nmyemail@email.com',
                                status=200)
         httpretty.register_uri(httpretty.GET,
-                               'http://www.naive.com/formspree_verify_myemail@email.com.txt',
+                               'http://www.naive.com/formspree-verify.txt',
+                               body='myemail@email.com',
                                status=200)
 
         # register user

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -231,9 +231,8 @@ class UserAccountsTestCase(FormspreeTestCase):
         self.assertEqual(0, Submission.query.count())
 
         # disable the form
-        r = self.client.post('/forms/toggle',
-            headers={'Referer': settings.SERVICE_URL},
-            data={'hashid': form_endpoint})
+        r = self.client.post('/forms/' + form_endpoint + '/toggle',
+            headers={'Referer': settings.SERVICE_URL})
         self.assertEqual(302, r.status_code)
         self.assertTrue(r.location.endswith('/dashboard'))
         self.assertTrue(Form.query.first().disabled)
@@ -241,9 +240,8 @@ class UserAccountsTestCase(FormspreeTestCase):
 
         # logout and attempt to enable the form
         self.client.get('/logout')
-        r = self.client.post('/forms/toggle',
+        r = self.client.post('/forms/' + form_endpoint + '/toggle',
             headers={'Referer': settings.SERVICE_URL},
-            data={'hashid': form_endpoint},
             follow_redirects=True)
         self.assertEqual(200, r.status_code)
         self.assertTrue(Form.query.first().disabled)
@@ -261,9 +259,8 @@ class UserAccountsTestCase(FormspreeTestCase):
             data={'email': 'hello@world.com',
                   'password': 'friend'}
         )
-        r = self.client.post('/forms/toggle',
+        r = self.client.post('/forms/' + form_endpoint + '/toggle',
             headers={'Referer': settings.SERVICE_URL},
-            data={'hashid': form_endpoint},
             follow_redirects=True)
         self.assertEqual(200, r.status_code)
         self.assertFalse(Form.query.first().disabled)
@@ -331,9 +328,8 @@ class UserAccountsTestCase(FormspreeTestCase):
 
         # delete a submission in form
         first_submission = Submission.query.first()
-        r = self.client.post('/forms/' + form_endpoint + '/delete',
+        r = self.client.post('/forms/' + form_endpoint + '/delete/' + unicode(first_submission.id),
             headers={'Referer': settings.SERVICE_URL},
-            data={'submissionid': unicode(first_submission.id)},
             follow_redirects=True)
         self.assertEqual(200, r.status_code)
         self.assertEqual(4, Submission.query.count())
@@ -343,9 +339,8 @@ class UserAccountsTestCase(FormspreeTestCase):
         self.client.get('/logout')
 
         # attempt to delete form you don't have access to (while logged out)
-        r = self.client.post('/forms/delete',
-            headers={'Referer': settings.SERVICE_URL},
-            data={'hashid': form_endpoint})
+        r = self.client.post('/forms/' + form_endpoint + '/delete',
+            headers={'Referer': settings.SERVICE_URL})
         self.assertEqual(302, r.status_code)
         self.assertEqual(1, Form.query.count())
 
@@ -356,9 +351,8 @@ class UserAccountsTestCase(FormspreeTestCase):
         )
 
         # attempt to delete form we don't have access to
-        r = self.client.post('/forms/delete',
-            headers={'Referer': settings.SERVICE_URL},
-            data={'hashid': form_endpoint})
+        r = self.client.post('/forms/' + form_endpoint + '/delete',
+            headers={'Referer': settings.SERVICE_URL})
         self.assertEqual(400, r.status_code)
         self.assertEqual(1, Form.query.count())
 
@@ -371,9 +365,8 @@ class UserAccountsTestCase(FormspreeTestCase):
         )
 
         # delete the form created
-        r = self.client.post('/forms/delete',
+        r = self.client.post('/forms/' + form_endpoint + '/delete',
             headers={'Referer': settings.SERVICE_URL},
-            data={'hashid': form_endpoint},
             follow_redirects=True)
         self.assertEqual(200, r.status_code)
         self.assertEqual(0, Form.query.count())


### PR DESCRIPTION
**Fixes issues raised by @colevscode on the poor state of the form creation modal**

**Changes proposed in this pull request:**

* Changes the verification method from checking for a file like `/formspree_verify_email@address.com.txt` to checking for a file like `/formspree-verify.txt` with email addresses listed inside (newline separated)
* Adds virtual-dom dependency for handling the multiple states of the form creation modal in a sane way
* Makes pure-CSS JS-enhanced modals fully-functional back again by checking triggering modals from JS based on the URL has (`#`)
* Change a little bit of everything in the layout, colours and display of forms list
* Changes modal with example form HTML to be copied and pasted from a black-and-white HTML form with 3 standard `<input>` fields to a declaratedly open HTML layout (with no `<input>` fields, since these are to be created by the user own imagination and needs) with highlighted markup
* Changes the concept of "new" form (for design purposes only) to forms without submissions
* Removes some old code not needed anymor.

**Have you made sure to add:**
- [ ] Tests - no, this is all frontend, we don't have a way to add these kinds of tests

**Screenshots**

![screenshot-spooner alhur es 5000 2016-03-29 19-27-39](https://cloud.githubusercontent.com/assets/1653275/14126155/8456c4c0-f5e5-11e5-8593-86adda44ded2.png)
![screenshot-spooner alhur es 5000 2016-03-29 19-26-18](https://cloud.githubusercontent.com/assets/1653275/14126158/85a9d0ec-f5e5-11e5-908f-21f040a46959.png)
![screenshot-spooner alhur es 5000 2016-03-29 19-24-11](https://cloud.githubusercontent.com/assets/1653275/14126172/a77c17fc-f5e5-11e5-8460-0064e726f380.png)
![screenshot-spooner alhur es 5000 2016-03-29 20-16-05](https://cloud.githubusercontent.com/assets/1653275/14126983/20670ea6-f5eb-11e5-885c-32466743ac03.png)
