### PR TITLE
Support multiple lines inside an email body

### DIFF
--- a/formspree/templates/email/form.html
+++ b/formspree/templates/email/form.html
@@ -39,7 +39,7 @@
 															{% for k in keys %}
 															<tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
 																<td width="30%" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; border-top-width: 1px; border-top-color: #eee; border-top-style: solid; margin: 0; padding: 5px 0;" valign="top"><strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">{{k}}</strong></td>
-																<td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; border-top-width: 1px; border-top-color: #eee; border-top-style: solid; margin: 0; padding: 5px 0;" valign="top">{{data.get(k,'')}}</td>
+																<td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; border-top-width: 1px; border-top-color: #eee; border-top-style: solid; margin: 0; padding: 5px 0;" valign="top"><pre style="font-family: inherit; box-sizing: border-box; font-size: 14px; margin: 0;">{{data.get(k,'')}}</pre></td>
 															</tr>
 															{% endfor %}
 														</table>

--- a/formspree/templates/email/pre_inline_style/form.html
+++ b/formspree/templates/email/pre_inline_style/form.html
@@ -12,7 +12,7 @@
 			<td></td>
 			<tr>
 				<td class="header">
-					<img src="{{url_for('static', filename='img/email_headers/form-confirmation@3x.png')}}" width="400">
+					<img src="{{url_for('static', filename='img/email_headers/new-submission@3x.png')}}" width="400">
 				</td>
 			</tr>
 			<td class="container" width="600">
@@ -40,7 +40,7 @@
 															{% for k in keys %}
 															<tr>
 																<td width="30%"><strong>{{k}}</strong></td>
-																<td>{{data.get(k,'')}}</td>
+																<td><pre style="margin: 0; font-family: inherit;">{{data.get(k,'')}}</pre></td>
 															</tr>
 															{% endfor %}
 														</table>


### PR DESCRIPTION
**Fixes #92.**

**Changes proposed in this pull request:**

* Support for multiple lines inside an email body

**Have you made sure to add:**
- [ ] Tests
- [ ] Documentation

(None necessary)

**Screenshots and GIFs**

<img width="757" alt="screen shot 2016-04-30 at 11 36 50 pm" src="https://cloud.githubusercontent.com/assets/6260066/14940116/754d9610-0f2c-11e6-956d-19a8e65180ee.png">


**Deploy notes**

No changes necessary.