### PR TITLE
Redirect to HTTPS

### DIFF
--- a/formspree/app.py
+++ b/formspree/app.py
@@ -8,6 +8,7 @@ from flask.ext.login import LoginManager, current_user
 from flask.ext.cdn import CDN
 from flask_redis import Redis
 import settings
+from helpers import ssl_redirect
 
 DB = SQLAlchemy()
 redis_store = Redis()
@@ -44,4 +45,6 @@ def create_app():
     app.config['CDN_DOMAIN'] = settings.CDN_URL
     app.config['CDN_HTTPS'] = True
     cdn.init_app(app)
+    if not app.debug and not app.testing:
+        ssl_redirect(app)
     return app

--- a/formspree/helpers.py
+++ b/formspree/helpers.py
@@ -1,0 +1,16 @@
+from flask import request, redirect
+
+def ssl_redirect(app):
+    app.before_request(get_redirect)
+    app.after_request(set_headers)
+    
+def get_redirect():
+    if not request.is_secure and request.method == 'GET' and request.url.startswith('http://'):
+        url = request.url.replace('http://', 'https://', 1)
+        r = redirect(url, code=301)
+        return r
+
+def set_headers(response):
+    if request.is_secure:
+        response.headers.setdefault('Strict-Transport-Security', 'max-age=31536000')
+    return response

--- a/formspree/helpers.py
+++ b/formspree/helpers.py
@@ -5,7 +5,7 @@ def ssl_redirect(app):
     app.after_request(set_headers)
     
 def get_redirect():
-    if not request.is_secure and request.method == 'GET' and request.url.startswith('http://'):
+    if not request.is_secure and not request.headers.get('X-Forwarded-Proto', 'http') == 'https' and request.method == 'GET' and request.url.startswith('http://'):
         url = request.url.replace('http://', 'https://', 1)
         r = redirect(url, code=301)
         return r

--- a/formspree/settings.py
+++ b/formspree/settings.py
@@ -6,6 +6,7 @@ import sys
 DEBUG = os.getenv('DEBUG') in ['True', 'true', '1', 'yes']
 if DEBUG:
     SQLALCHEMY_ECHO = True
+TESTING = os.getenv('TESTING') in ['True', 'true', '1', 'yes']
 
 SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL')
 

--- a/tests/formspree_test_case.py
+++ b/tests/formspree_test_case.py
@@ -23,7 +23,7 @@ class FormspreeTestCase(TestCase):
         settings.STRIPE_SECRET_KEY = settings.STRIPE_TEST_SECRET_KEY
         settings.SERVICE_URL = os.getenv('SERVICE_URL')
         settings.PRESERVE_CONTEXT_ON_EXCEPTION = False
-
+        settings.TESTING = True
         return create_app()
 
     def setUp(self):


### PR DESCRIPTION
**Fixes #85.**

**Changes proposed in this pull request:**

* Forward GET requests over HTTP to redirect to HTTPS
* Do **NOT** forward POST requests sent over HTTP to be redirected to HTTPS. This is because this would require using the 307 status code, which has unknown implementation on older browsers. Additionally, any POST requests sent over HTTP would have already exposed sensitive information unencrypted, rendering the useless, only causing additional server load. #86 does encourage users to use the HTTPS URL going forward

**Have you made sure to add:**
- [X] Tests
- [ ] Documentation

**Any Additional Information**

None necessary