### PR TITLE
Proof of concept file upload (singular only)

### DIFF
--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -110,6 +110,7 @@ class Form(DB.Model):
         next = next_url(referrer, data.get('_next'))
         spam = data.get('_gotcha', None)
         format = data.get('_format', None)
+        attachments = data.get('_attachment', None)
 
 		# turn cc emails into array
         if cc:
@@ -183,8 +184,9 @@ class Form(DB.Model):
                           text=text,
                           html=html,
                           sender=settings.DEFAULT_SENDER,
+                          cc=cc,
                           reply_to=reply_to,
-                          cc=cc)
+                          files=attachments)
 
         if not result[0]:
             if result[1].startswith('Invalid replyto email address'):

--- a/formspree/utils.py
+++ b/formspree/utils.py
@@ -96,7 +96,7 @@ def next_url(referrer=None, next=None):
     return urlparse.urlunparse(parsed)
 
 
-def send_email(to=None, subject=None, text=None, html=None, sender=None, cc=None, reply_to=None):
+def send_email(to=None, subject=None, text=None, html=None, sender=None, cc=None, reply_to=None, files=None):
     '''
     Sends email using SendGrid's REST-api
     '''
@@ -109,7 +109,8 @@ def send_email(to=None, subject=None, text=None, html=None, sender=None, cc=None
             'to': to,
             'subject': subject,
             'text': text,
-            'html': html}
+            'html': html
+            'files': files}
 
     # parse 'fromname' from 'sender' if it is formatted like "Name <name@email.com>"
     try:


### PR DESCRIPTION
**Fixes #101  .**

**Changes proposed in this pull request:**
* To use Sendgrid's web API to send a user-uploaded file as an attachment via the following command in the form: `<input type="file" name="_attachment">`.

**Any Additional Information**
This was just a first pass on trying to get file uploads sent as attachments. If there's another way already planned, then my apologies for missing them when I skimmed over the issues. If this doesn't work, please let me know so we can figure out another way, or bugfix the original.
