### PR TITLE
reject form submission when _replyto does not validate.

### DIFF
--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -150,16 +150,13 @@ def send(email_or_string):
         if request_wants_json():
             return jsonify({'error': "form over quota"})
         else:
-            return render_template('error.html',
-                                   title='Form over quota',
-                                   text='It looks like this form is getting a lot of submissions and ran out of its quota. Try contacting this website through other means or try submitting again later.'
-            )
+            return render_template('error.html', title='Form over quota', text='It looks like this form is getting a lot of submissions and ran out of its quota. Try contacting this website through other means or try submitting again later.'), 402
 
     elif status['code'] == Form.STATUS_REPLYTO_ERROR:
         if request_wants_json():
             return jsonerror(500, {'error': "_replyto or email field has not been sent correctly"})
         else:
-            return render_template('error.html', title='Unable to send email', text='Unable to send email. The field with a name attribute _replyto or email was not set correctly. This may be the result of you have multiple _replyto or email fields. If you cannot find your error, please contact <b>{email}</b> with a link to your form and this error message: <p><pre><code>{message}</code></pre></p>'.format(message=status['error-message'], email=settings.CONTACT_EMAIL)), 500
+            return render_template('error.html', title='Unable to send email', text='Unable to send email. The field with a name attribute _replyto or email was not set correctly. This may be the result of you having multiple _replyto or email fields in the form. If you cannot find your error, please contact <b>{email}</b> with a link to your form and this error message: <p><pre><code>{message}</code></pre></p>'.format(message=status['error-message'], email=settings.CONTACT_EMAIL)), 400
 
     # error fallback -- shouldn't happen
     if request_wants_json():

--- a/formspree/utils.py
+++ b/formspree/utils.py
@@ -121,7 +121,7 @@ def send_email(to=None, subject=None, text=None, html=None, sender=None, cc=None
     except ValueError:
         data.update({'from': sender})
 
-    if reply_to and IS_VALID_EMAIL(reply_to):
+    if reply_to:
         data.update({'replyto': reply_to})
 
     if cc:


### PR DESCRIPTION
Implements https://trello.com/c/gJ2EtOYF/3206-validate-replyto-field-reject-invalid-email-addresses

**Changes proposed in this pull request:**

* When the `_replyto` or `email` field does not match the email regex, reject the submission and show an error message.

**Have you made sure to add:**
- [x] Tests
- [ ] Documentation (is it needed?)

**Screenshot**
![](http://i.imgur.com/KdVWf8F.png)