### PR TITLE
replacing contact form with a newsletter signup

### DIFF
--- a/formspree/settings.py
+++ b/formspree/settings.py
@@ -26,6 +26,7 @@ SERVICE_NAME = os.getenv('SERVICE_NAME') or 'Forms'
 UPGRADED_PLAN_NAME = os.getenv('UPGRADED_PLAN_NAME') or 'Gold'
 SERVICE_URL = os.getenv('SERVICE_URL') or 'http://example.com'
 CONTACT_EMAIL = os.getenv('CONTACT_EMAIL') or 'team@example.com'
+NEWSLETTER_EMAIL = os.getenv('NEWSLETTER_EMAIL') or 'signup@example.com'
 DEFAULT_SENDER = os.getenv('DEFAULT_SENDER') or 'Forms Team <submissions@example.com>'
 ACCOUNT_SENDER = os.getenv('ACCOUNT_SENDER') or DEFAULT_SENDER
 API_ROOT = os.getenv('API_ROOT') or '//example.com'

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -256,15 +256,15 @@
   <div class="row section">
       <div class="container narrow block">
           <div class="col-1-2">
-            <p>{{config.SERVICE_NAME}} is a tool <a href="https://github.com/formspree/formspree">managed on GitHub</a>. To contact us send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a> or use the form on the right.</p>
+            <p>{{config.SERVICE_NAME}} is a tool <a href="https://github.com/formspree/formspree">managed on GitHub</a>. To contact us send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a>. To sign up for our newsletter, use the form on the right.</p>
           </div>
           <div class="col-1-2">
-            <form method="POST" action="{{config.API_ROOT}}/{{config.CONTACT_EMAIL}}">
+            <form method="POST" action="{{config.API_ROOT}}/{{config.NEWSLETTER_EMAIL}}">
+              <input type="text" name="name" placeholder="Your name" required />
               <input type="email" name="_replyto" placeholder="Your email" required />
-              <textarea name="message" rows="5" placeholder="Your message (when sending support requests, please include the URL to your form if that is relevant)" required></textarea>
               <input type="text" name="_gotcha" style="display:none">
               <input type="hidden" name="_format" value="plain" style="display:none">
-              <button type="submit">Send</button>
+              <button style="width: 100%" type="submit">Get Our Newsletter</button>
             </form>
           </div>
       </div>


### PR DESCRIPTION
**Changes proposed in this pull request:**
* Replaces test form at bottom of page with newsletter signup form. 
* Adds newletter email to settings

The intention with this change is to use a parser.zaper.com email address, and then create a zap that wires up the email submissions to mailchimp.

**Have you made sure to add:**
- [ ] Tests
- [ ] Documentation

**Screenshots and GIFs**
![screen shot 2016-06-04 at 7 49 41 pm](https://cloud.githubusercontent.com/assets/409293/15802835/c0c22c6e-2a8e-11e6-85d8-594cb8c13ebb.png)

**Deploy notes**

I should merge this so that I can quickly configure the zapier / mailchimp integration.

