### PR TITLE
Support unicode emails.

### DIFF
--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -8,7 +8,7 @@ from flask import request, g
 
 from formspree import settings
 
-HASH = lambda x, y: hashlib.md5(x+y+settings.NONCE_SECRET).hexdigest()
+HASH = lambda x, y: hashlib.md5(x.encode('utf-8')+y.encode('utf-8')+settings.NONCE_SECRET).hexdigest()
 EXCLUDE_KEYS = {'_gotcha', '_next', '_subject', '_cc', '_format'}
 MONTHLY_COUNTER_KEY = 'monthly_{form_id}_{month}'.format
 HASHIDS_CODEC = hashids.Hashids(alphabet='abcdefghijklmnopqrstuvwxyz',

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -146,9 +146,11 @@ def send(email_or_string):
         if request_wants_json():
             return jsonerror(400, {'error': "Can't send an empty form"})
         else:
-            return render_template('error.html',
-                                   title='Can\'t send an empty form',
-                                   text=str('<p>Make sure you have placed the <a href="http://www.w3schools.com/tags/att_input_name.asp" target="_blank"><code>"name"</code> attribute</a> in all your form elements. Also, to prevent empty form submissions, take a look at the <a href="http://www.w3schools.com/tags/att_input_required.asp" target="_blank"><code>"required"</code> property</a>.</p><p>This error also happens when you have an <code>"enctype"</code> attribute set in your <code>&lt;form&gt;</code>, so make sure you don\'t.</p><p><a href="%s">Return to form</a></p>' % request.referrer)), 400
+            return render_template(
+                'error.html',
+                title='Can\'t send an empty form',
+                text=u'<p>Make sure you have placed the <a href="http://www.w3schools.com/tags/att_input_name.asp" target="_blank"><code>"name"</code> attribute</a> in all your form elements. Also, to prevent empty form submissions, take a look at the <a href="http://www.w3schools.com/tags/att_input_required.asp" target="_blank"><code>"required"</code> property</a>.</p><p>This error also happens when you have an <code>"enctype"</code> attribute set in your <code>&lt;form&gt;</code>, so make sure you don\'t.</p><p><a href="{}">Return to form</a></p>'.format(request.referrer)
+            ), 400
     elif status['code'] == Form.STATUS_CONFIRMATION_SENT or \
          status['code'] == Form.STATUS_CONFIRMATION_DUPLICATED:
 
@@ -170,15 +172,21 @@ def send(email_or_string):
         if request_wants_json():
             return jsonerror(500, {'error': "_replyto or email field has not been sent correctly"})
         else:
-            return render_template('error.html', title='Invalid email address', text='You entered <span class="code">{address}</span>. That is an invalid email address. Please correct the form and try to submit again <a href="{back}">here</a>.<p style="font-size: small">This could also be a problem with the form. For example, there could be two fields with <span class="code">_replyto</span> or <span class="code">email</span> name attribute. If you suspect the form is broken, please contact the form owner and ask them to investigate</p>'''.format(address=status['address'], back=status['referrer'])), 400
+            return render_template(
+                'error.html',
+                title='Invalid email address',
+                text=u'You entered <span class="code">{address}</span>. That is an invalid email address. Please correct the form and try to submit again <a href="{back}">here</a>.<p style="font-size: small">This could also be a problem with the form. For example, there could be two fields with <span class="code">_replyto</span> or <span class="code">email</span> name attribute. If you suspect the form is broken, please contact the form owner and ask them to investigate</p>'''.format(address=status['address'], back=status['referrer'])
+            ), 400
 
     # error fallback -- shouldn't happen
     if request_wants_json():
         return jsonerror(500, {'error': "Unable to send email"})
     else:
-        return render_template('error.html',
-                               title='Unable to send email',
-                               text='Unable to send email. If you can, please send the link to your form and the error information to  <b>{email}</b>. And send them the following: <p><pre><code>{message}</code></pre></p>'.format(message=json.dumps(status), email=settings.CONTACT_EMAIL)), 500
+        return render_template(
+            'error.html',
+            title='Unable to send email',
+            text=u'Unable to send email. If you can, please send the link to your form and the error information to  <b>{email}</b>. And send them the following: <p><pre><code>{message}</code></pre></p>'.format(message=json.dumps(status), email=settings.CONTACT_EMAIL)
+        ), 500
 
 
 def resend_confirmation(email):
@@ -366,7 +374,7 @@ def create_form():
         if request_wants_json():
             return jsonerror(400, {'error': "The provided email address is not valid."})
         else:
-            flash('The provided email address is not valid.', 'error')
+            flash(u'The provided email address is not valid.', 'error')
             return redirect(url_for('dashboard'))
 
     g.log.info('Creating a new form from the dashboard.')
@@ -383,7 +391,9 @@ def create_form():
                 form.host = remove_www(referrer_to_path(urljoin(url, '/'))[:-1])
                 form.sitewide = True
             else:
-                return jsonerror(403, {'error': "Couldn't verify the file at %s." % url})
+                return jsonerror(403, {
+                    'error': u"Couldn't verify the file at {}.".format(url)
+                })
 
     DB.session.add(form)
     DB.session.commit()
@@ -411,7 +421,7 @@ def create_form():
             'confirmed': form.confirmed
         })
     else:
-        flash('Your new form endpoint was created!', 'success')
+        flash(u'Your new form endpoint was created!', 'success')
         return redirect(url_for('dashboard', new=form.hashid) + '#form-' + form.hashid)
 
 
@@ -523,9 +533,9 @@ def form_toggle(hashid):
         DB.session.add(form)
         DB.session.commit()
         if form.disabled:
-            flash('Form successfully disabled', 'success')
+            flash(u'Form successfully disabled', 'success')
         else:
-            flash('Form successfully enabled', 'success')
+            flash(u'Form successfully enabled', 'success')
         return redirect(url_for('dashboard'))
 
 
@@ -555,7 +565,7 @@ def form_deletion(hashid):
             DB.session.delete(submission)
         DB.session.delete(form)
         DB.session.commit()
-        flash('Form successfully deleted', 'success')
+        flash(u'Form successfully deleted', 'success')
         return redirect(url_for('dashboard'))
 
 
@@ -590,5 +600,5 @@ def submission_deletion(hashid, submissionid):
         form.counter -= 1
         DB.session.add(form)
         DB.session.commit()
-        flash('Submission successfully deleted', 'success')
+        flash(u'Submission successfully deleted', 'success')
         return redirect(url_for('form-submissions', hashid=hashid))

--- a/formspree/templates/layouts/base.html
+++ b/formspree/templates/layouts/base.html
@@ -27,9 +27,9 @@ ga('send', 'pageview');
       <div class="row">
         <div class="container">
             <div class="col-1-1">
-            {% for category, message in messages %}
+            {% for category, flashed in messages %}
               <div class="alert-box {{ category }} banner">
-               {{ message|safe }}
+               {{ flashed|safe }}
               </div>
             {% endfor %}
            </div>

--- a/formspree/users/models.py
+++ b/formspree/users/models.py
@@ -113,11 +113,17 @@ class Email(DB.Model):
         addr = addr.lower().strip()
         if not IS_VALID_EMAIL(addr):
             g.log.info('Failed. Invalid address.')
-            raise ValueError('Cannot send confirmation. %s is not a valid email.' % addr)
+            raise ValueError(u'Cannot send confirmation. '
+                             '{} is not a valid email.'.format(addr))
 
-        message = 'email={email}&user_id={user_id}'.format(email=addr, user_id=user_id)
-        digest = hmac.new(settings.NONCE_SECRET, message, hashlib.sha256).hexdigest()
-        link = url_for('confirm-account-email', digest=digest, email=addr, _external=True)
+        message = u'email={email}&user_id={user_id}'.format(
+            email=addr,
+            user_id=user_id)
+        digest = hmac.new(
+            settings.NONCE_SECRET, message.encode('utf-8'), hashlib.sha256
+        ).hexdigest()
+        link = url_for('confirm-account-email',
+                       digest=digest, email=addr, _external=True)
         res = send_email(
             to=addr,
             subject='Confirm email for your account at %s' % settings.SERVICE_NAME,
@@ -134,8 +140,12 @@ class Email(DB.Model):
     @classmethod
     def create_with_digest(cls, addr, user_id, digest):
         addr = addr.lower()
-        message = 'email={email}&user_id={user_id}'.format(email=addr, user_id=user_id)
-        what_should_be = hmac.new(settings.NONCE_SECRET, message, hashlib.sha256).hexdigest()
+        message = u'email={email}&user_id={user_id}'.format(
+            email=addr,
+            user_id=user_id)
+        what_should_be = hmac.new(
+            settings.NONCE_SECRET, message.encode('utf-8'), hashlib.sha256
+        ).hexdigest()
         if digest == what_should_be:
             return cls(address=addr, owner_id=user_id)
         else:

--- a/tests/test_email_confirmations.py
+++ b/tests/test_email_confirmations.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import httpretty
 import json
 
@@ -42,20 +44,20 @@ class EmailConfirmationsTestCase(FormspreeTestCase):
     def test_user_gets_previous_forms_assigned_to_him(self):
         httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
 
-        # verify a form for mark@example.com
-        self.client.post('/mark@example.com',
+        # verify a form for márkö@example.com
+        self.client.post(u'/márkö@example.com',
             headers = {'Referer': 'tomatoes.com'},
             data={'name': 'alice'}
         )
-        f = Form.query.filter_by(host='tomatoes.com', email='mark@example.com').first()
+        f = Form.query.filter_by(host='tomatoes.com', email=u'márkö@example.com').first()
         f.confirm_sent = True
         f.confirmed = True
         DB.session.add(f)
         DB.session.commit()
 
-        # register mark@example.com
+        # register márkö@example.com
         r = self.client.post('/register',
-            data={'email': 'mark@example.com',
+            data={'email': u'márkö@example.com',
                   'password': 'russia'}
         )
 
@@ -78,7 +80,7 @@ class EmailConfirmationsTestCase(FormspreeTestCase):
         self.assertEqual(0, len(forms))
 
         # upgrade user
-        user = User.query.filter_by(email='mark@example.com').first()
+        user = User.query.filter_by(email=u'márkö@example.com').first()
         user.upgraded = True
         DB.session.add(user)
         DB.session.commit()
@@ -89,7 +91,7 @@ class EmailConfirmationsTestCase(FormspreeTestCase):
         )
         forms = json.loads(r.data)['forms']
         self.assertEqual(1, len(forms))
-        self.assertEqual(forms[0]['email'], 'mark@example.com')
+        self.assertEqual(forms[0]['email'], u'márkö@example.com')
         self.assertEqual(forms[0]['host'], 'tomatoes.com')
 
         # verify a form for another address
@@ -126,11 +128,11 @@ class EmailConfirmationsTestCase(FormspreeTestCase):
         self.assertEqual(forms[0]['host'], 'mark.com')
 
         # create a new form spontaneously with an email already verified
-        r = self.client.post('/mark@example.com',
+        r = self.client.post(u'/márkö@example.com',
             headers = {'Referer': 'elsewhere.com'},
             data={'name': 'luke'}
         )
-        f = Form.query.filter_by(host='elsewhere.com', email='mark@example.com').first()
+        f = Form.query.filter_by(host='elsewhere.com', email=u'márkö@example.com').first()
         f.confirm_sent = True
         f.confirmed = True
         DB.session.add(f)
@@ -142,5 +144,5 @@ class EmailConfirmationsTestCase(FormspreeTestCase):
         )
         forms = json.loads(r.data)['forms']
         self.assertEqual(3, len(forms))
-        self.assertEqual(forms[0]['email'], 'mark@example.com')
+        self.assertEqual(forms[0]['email'], u'márkö@example.com')
         self.assertEqual(forms[0]['host'], 'elsewhere.com')

--- a/tests/test_form_creation.py
+++ b/tests/test_form_creation.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import httpretty
 import json
 
@@ -152,11 +154,11 @@ class TestFormCreationFromDashboard(FormspreeTestCase):
     def test_sitewide_forms(self):
         httpretty.register_uri(httpretty.GET,
                                'http://mysite.com/formspree-verify.txt',
-                               body='other_email@forms.com\nmyemail@email.com',
+                               body=u'other_email@forms.com\nmyüñìćõð€email@email.com',
                                status=200)
         httpretty.register_uri(httpretty.GET,
                                'http://www.naive.com/formspree-verify.txt',
-                               body='myemail@email.com',
+                               body=u'myüñìćõð€email@email.com',
                                status=200)
 
         # register user
@@ -172,7 +174,7 @@ class TestFormCreationFromDashboard(FormspreeTestCase):
 
         # manually verify an email
         email = Email()
-        email.address = 'myemail@email.com'
+        email.address = u'myüñìćõð€email@email.com'
         email.owner_id = user.id
         DB.session.add(email)
         DB.session.commit()
@@ -180,7 +182,7 @@ class TestFormCreationFromDashboard(FormspreeTestCase):
         # create a sitewide form with the verified email address
         r = self.client.post('/forms',
             headers={'Accept': 'application/json', 'Content-type': 'application/json'},
-            data=json.dumps({'email': 'myemail@email.com',
+            data=json.dumps({'email': u'myüñìćõð€email@email.com',
                              'url': 'http://mysite.com',
                              'sitewide': 'true'})
         )
@@ -219,7 +221,7 @@ class TestFormCreationFromDashboard(FormspreeTestCase):
         # another form, now with a www prefix that will be stripped
         r = self.client.post('/forms',
             headers={'Accept': 'application/json', 'Content-type': 'application/json'},
-            data=json.dumps({'email': 'myemail@email.com',
+            data=json.dumps({'email': u'myüñìćõð€email@email.com',
                              'url': 'http://www.naive.com',
                              'sitewide': 'true'})
         )
@@ -238,19 +240,19 @@ class TestFormCreationFromDashboard(FormspreeTestCase):
         httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
 
         r = self.client.post('/' + form.hashid,
-            headers = {'Referer': 'http://naive.com/hipopotamo', 'content-type': 'application/json'},
+            headers={'Referer': 'http://naive.com/hipopotamo', 'content-type': 'application/json'},
             data=json.dumps({'name': 'alice'})
         )
         self.assertIn('alice', httpretty.last_request().body)
 
         self.client.post('/' + form.hashid,
-            headers = {'Referer': 'http://www.naive.com/baleia/urso?w=2', 'content-type': 'application/json'},
+            headers={'Referer': 'http://www.naive.com/baleia/urso?w=2', 'content-type': 'application/json'},
             data=json.dumps({'name': 'maria'})
         )
         self.assertIn('maria', httpretty.last_request().body)
 
         self.client.post('/' + form.hashid,
-            headers = {'Referer': 'http://www.naive.com/', 'content-type': 'application/json'},
+            headers={'Referer': 'http://www.naive.com/', 'content-type': 'application/json'},
             data=json.dumps({'name': 'laura'})
         )
         self.assertIn('laura', httpretty.last_request().body)
@@ -258,7 +260,7 @@ class TestFormCreationFromDashboard(FormspreeTestCase):
         # create a different form with the same email address, now using unprefixed url
         r = self.client.post('/forms',
             headers={'Accept': 'application/json', 'Content-type': 'application/json'},
-            data=json.dumps({'email': 'myemail@email.com',
+            data=json.dumps({'email': u'myüñìćõð€email@email.com',
                              'url': 'mysite.com',
                              'sitewide': 'true'})
         )


### PR DESCRIPTION
**Fixes https://trello.com/c/qsGeTz2m/4727-support-unicode-emails and many other occurrences.**

**Changes proposed in this pull request:**

* Uses unicode objects in `flash` messages and manually-built HTML.
* In some places (3, I think) manually encode email addresses to UTF-8.
* Reformat some lines of code where strings were too big, chunking them to multiple lines. This is not related to the functionality, but since I was already messing with these lines I thought it would be a good thing.

**Have you made sure to add:**
- [x] Tests
- [ ] Documentation

The "tests" here are just some random changes in email addresses used in existing tests that I've changed to unicode strings with non-ascii characters.

**Deploy notes**

Nothing.

**Any Additional Information**
Just using u'unicode' in all the arbitrary strings built by normal string building, everything will be handled nicely by Flask.

Flask already gives us all parameters and form values in unicode objects, and does the nice handling transparently in render_template, so not many changes are needed.