### PR TITLE
add knowledge base link to home page.

### DIFF
--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -257,7 +257,7 @@
   <div class="row section">
       <div class="container narrow block">
           <div class="col-1-2">
-            <p>{{config.SERVICE_NAME}} is a tool <a href="https://github.com/formspree/formspree">managed on GitHub</a>. To contact us send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a>. To sign up for our newsletter, use the form on the right.</p>
+            <p>If you have a problem, please look <a href="http://help.formspree.io/">here</a> first, or send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a>. To sign up for our newsletter, use the form on the right.</p>
             <p>For a quick demo of Formspree, <a href="http://testformspree.com/" target="_blank">click here</a>.</p>
           </div>
           <div class="col-1-2">
@@ -275,8 +275,8 @@
           <a href="//facebook.com/formspree"><i class="fa fa-facebook-official fa-2x"></i></a>
           <a href="//twitter.com/formspree"><i class="fa fa-twitter fa-2x"></i></a>
           <a href="//github.com/formspree/formspree"><i class="fa fa-github fa-2x"></i></a>
-
         </div>
+        <p class="col-1-1 center">{{config.SERVICE_NAME}} is a tool <a href="https://github.com/formspree/formspree">managed on GitHub</a>.</p>
       </div>
 
   </div>


### PR DESCRIPTION
Based on https://trello.com/c/AIN5tAkT

The link is http://help.formspree.io/

I've also moved the "managed on GitHub" part to the bottom of the page. I didn't know what to do to shorten that paragraph, but this seemed a good solution since there is already a mention of the GitHub repo and organization on the "Questions" section above.

![screenshot-cantillon alhur es 4333 2016-11-29 11-51-35](https://cloud.githubusercontent.com/assets/1653275/20712350/c96c1596-b62a-11e6-8510-18a2bbd84fd3.png)
