### PR TITLE
Fix several display issues with long text in <pre> tag

### DIFF
--- a/formspree/templates/email/form.html
+++ b/formspree/templates/email/form.html
@@ -39,7 +39,7 @@
 															{% for k in keys %}
 															<tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
 																<td width="30%" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; border-top-width: 1px; border-top-color: #eee; border-top-style: solid; margin: 0; padding: 5px 0;" valign="top"><strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">{{k}}</strong></td>
-																<td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; border-top-width: 1px; border-top-color: #eee; border-top-style: solid; margin: 0; padding: 5px 0;" valign="top"><pre style="font-family: inherit; box-sizing: border-box; font-size: 14px; margin: 0;">{{data.get(k,'')}}</pre></td>
+																<td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; border-top-width: 1px; border-top-color: #eee; border-top-style: solid; margin: 0; padding: 5px 0;" valign="top"><pre style="font-family: inherit; box-sizing: border-box; font-size: 14px; margin: 0; white-space: pre-wrap;">{{data.get(k,'')}}</pre></td>
 															</tr>
 															{% endfor %}
 														</table>

--- a/formspree/templates/email/plain_form.html
+++ b/formspree/templates/email/plain_form.html
@@ -11,7 +11,7 @@
         <tr>
             <td align="right" valign="top" width="70" style="padding: 5px 5px 5px 0;"><strong>{{k}}:</strong> </td>
             <td align="left" valign="top" width="*" style="padding: 5px 5px 5px;">
-              <pre style="margin: 0; font-family: inherit;">{{data.get(k,'')}}</pre>
+              <pre style="margin: 0; font-family: inherit; white-space: pre-wrap;">{{data.get(k,'')}}</pre>
             </td>
         </tr>
     {% endfor %}


### PR DESCRIPTION
**Changes proposed in this pull request:**

Long strings of text were causing display issues in several email clients (see screenshots below for examples). This is due to the default line wrapping behavior of the `<pre>` tags which hold the form field values. This does not seem to be affecting short text strings (I noticed the issue with ~1000 characters from a `<textarea>` element). This affects both the HTML and plain versions of the email, since both versions are using `<pre>` tags. The following email clients had display issues (tested in Litmus):
 * Apple Mail 9 & 10
 * Outlook 2000-2003, 2011, 2016
 * AOL Mail
 * Inbox by Gmail
 * Office 365
 * Outlook.com

I fixed this by adding `white-space: pre-wrap;` to the inline styles on the `<pre>` tags. This keeps the original white space formatting from the form submission, but also allows the text to wrap naturally. According to Litmus, this fixed all of the email clients listed above, except for the oldest versions of Outlook. I also confirmed that this did not break any clients that were already displaying correctly.


**Have you made sure to add:**
- [ ] Tests
- [ ] Documentation

None required

**Screenshots and GIFs**

![screen shot 2016-11-29 at 10 10 14 am](https://cloud.githubusercontent.com/assets/5910374/20722118/0ac66fbe-b62b-11e6-828b-cbe335cfebf9.png)

![screen shot 2016-11-29 at 10 06 02 am](https://cloud.githubusercontent.com/assets/5910374/20722117/0ac448ce-b62b-11e6-982c-6da9594faa60.png)


**Deploy notes**

N/A

**Any Additional Information**

N/A
