### PR TITLE
do not send Strict-Transport-Security header.

### DIFF
--- a/formspree/app.py
+++ b/formspree/app.py
@@ -44,13 +44,6 @@ def configure_ssl_redirect(app):
             r = redirect(url, code=301)
             return r
 
-    @app.after_request
-    def set_headers(response):
-        if request.is_secure:
-            response.headers.setdefault('Strict-Transport-Security',
-                                        'max-age=31536000')
-        return response
-
 
 def configure_logger(app):
     def processor(_, method, event):


### PR DESCRIPTION
**Fixes https://trello.com/c/muk9EBuA**

**Changes proposed in this pull request:**

* Removed code that sent `Strict-Transport-Security` header.

**Have you made sure to add:**
- [ ] Tests (not needed, untestable)
- [ ] Documentation (not needed)

HSTS doesn't seem to work well for Formspree.

Copy-pasted from https://trello.com/c/muk9EBuA#comment-583f518d568f990567511af4:

> [This code here](https://github.com/formspree/formspree/blob/246efe60e07f1a24c93f187f6a2b7e1a1ab0239c/formspree/app.py#L50-L51) is setting an HSTS policy on the browsers of everybody who visits https://formspree.io/.
> 
> I didn't know what was HSTS until now.
> 
> Later, when that same user tries to submit a form from another page, if the `action` attribute is set to `http://formspr...` the browser will perform an 307 INTERNAL REDIRECT by itself, without touching the server, and then submit to `https://formspr...`.
> 
> However, in some occasions this submission will be done without the _Referer_ header, hence the problem a lot of users are complaining.
> 
> It seems that for some browsers (old Safari and mobile Safari) the Referer header is never sent after the INTERNAL REDIRECT; for other browsers (my Chromium 53, for example) the Referer header is sent if the original site is `http://`, but not if the original site is `https://`.
> 
> I guess HSTS people didn't think about the possibility of `<form>`s on external domains submitting to HSTS-enabled domains, since if the `<form>`s were on the same HSTS domain they would be automatically targeting `https://` handlers.
> 
> To test what I am saying, find some Formspree form that is failing because of this (or modify the form on https://formspree.io manually in the browser) and spot the 307 INTERNAL REDIRECT response in your browser's devtools. Then [clear the HSTS settings](http://classically.me/blogs/how-clear-hsts-settings-major-browsers) for `formspree.io` and redo the experiment.
> 
> I suggest that we remove the HSTS-enabling code until we find another way of doing it.