### PR TITLE
only set HSTS on GET requests

### DIFF
--- a/formspree/app.py
+++ b/formspree/app.py
@@ -46,7 +46,7 @@ def configure_ssl_redirect(app):
 
     @app.after_request
     def set_headers(response):
-        if request.is_secure:
+        if request.is_secure and request.method == 'GET':
             response.headers.setdefault('Strict-Transport-Security',
                                         'max-age=31536000')
         return response


### PR DESCRIPTION
**Fixes #126.**

**Changes proposed in this pull request:**
* #126 doesn't enforce our HSTS policy on GET requests. This will still protect against protocol downgrade attacks on GET requests when performing GET requests on the Formspree website to keep username/passwords secure.


**Have you made sure to add:**
- [ ] Tests
- [ ] Documentation

**Any Additional Information**
