### PR TITLE
remove slashes at the end of input

### DIFF
--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -123,7 +123,7 @@
             <div class="col-1-1">
                 <h4><span class="code">_replyto</span> or <span class="code">email</span></h4>
                 <p>This value is used for the email's Reply-To field. This way you can directly "Reply" to the email to respond to the person who originally submitted the form.</p>
-                <p><input type="text" class="code" value='<input type="text" name="_replyto" placeholder="Your email" />'></p>
+                <p><input type="text" class="code" value='<input type="text" name="_replyto" placeholder="Your email">'></p>
             </div>
       </div>
 
@@ -131,7 +131,7 @@
             <div class="col-1-1">
                 <h4><span class="code">_next</span></h4>
                 <p>By default, after submitting a form the user is shown the {{config.SERVICE_NAME}} "Thank You" page. You can provide an alternative URL for that page.</p>
-                <p><input type="text" class="code" value='<input type="hidden" name="_next" value="//site.io/thanks.html" />'></p>
+                <p><input type="text" class="code" value='<input type="hidden" name="_next" value="//site.io/thanks.html">'></p>
             </div>
       </div>
 
@@ -139,7 +139,7 @@
             <div class="col-1-1">
                 <h4><span class="code">_subject</span></h4>
                 <p>This value is used for the email's subject, so that you can quickly reply to submissions without having to edit the subject line each time.</p>
-                <p><input type="text" class="code" value='<input type="hidden" name="_subject" value="New submission!" />'></p>
+                <p><input type="text" class="code" value='<input type="hidden" name="_subject" value="New submission!">'></p>
             </div>
       </div>
 
@@ -147,9 +147,9 @@
             <div class="col-1-1">
                 <h4><span class="code">_cc</span></h4>
                 <p>This value is used for the email's CC Field. This lets you send a copy of each submission to another email address.</p>
-                <p><input type="text" class="code" value='<input type="hidden" name="_cc" value="another@email.com" />'></p>
+                <p><input type="text" class="code" value='<input type="hidden" name="_cc" value="another@email.com">'></p>
 				<p>If you want to CC multiple email addresses, then just make it a list of email addresses separate by commas.</p>
-                <p><input type="text" class="code" value='<input type="hidden" name="_cc" value="another@email.com,yetanother@email.com" />'></p>
+                <p><input type="text" class="code" value='<input type="hidden" name="_cc" value="another@email.com,yetanother@email.com">'></p>
             </div>
       </div>
 
@@ -157,7 +157,7 @@
             <div class="col-1-1">
                 <h4><span class="code">_format</span></h4>
                 <p>Adding this to your form will allow for you to receive plain text versions of emails for form submissions.</p>
-                <p><input type="text" class="code" value='<input type="hidden" name="_format" value="plain" />'></p>
+                <p><input type="text" class="code" value='<input type="hidden" name="_format" value="plain">'></p>
             </div>
       </div>
 
@@ -165,7 +165,7 @@
             <div class="col-1-1">
                 <h4><span class="code">_gotcha</span></h4>
                 <p>Add this "honeypot" field to avoid spam by fooling scrapers. If a value is provided, the submission will be silently ignored. The input should be hidden with CSS.</p>
-                <p><input type="text" class="code" value='<input type="text" name="_gotcha" style="display:none" />'></p>
+                <p><input type="text" class="code" value='<input type="text" name="_gotcha" style="display:none">'></p>
             </div>
       </div>
 


### PR DESCRIPTION
Slashes at the end of input elements may be omitted in HTML5. Please see https://www.w3.org/TR/html5/forms.html#the-input-element for examples.

`<input type="text" />` can be written as `<input type="text">`