### PR TITLE
cleaning up css styles for mobile. Removing menu on confirmation

### DIFF
--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -211,7 +211,6 @@ table {
     height: 0; }
 
 .container {
-  width: 100%;
   max-width: 950px;
   margin: 0 auto; }
   .container:after {
@@ -221,8 +220,9 @@ table {
     visibility: hidden;
     line-height: 0;
     height: 0; }
-  .container.narrow {
-    max-width: 600px; }
+  @media (min-width: 760px) {
+    .container.narrow {
+      max-width: 600px; } }
   @media (max-width: 760px) {
     .container {
       max-width: 100% !important; } }
@@ -717,7 +717,6 @@ a.alert-box.success:hover {
           border-bottom: 5px solid #ddd; }
           .dashboard table.responsive tr td {
             display: block;
-            text-align: center;
             font-size: 13px;
             border-bottom: 1px dotted #ccc;
             margin: 10px auto;
@@ -727,7 +726,6 @@ a.alert-box.success:hover {
           .dashboard table.responsive tr td:before {
             content: attr(data-label);
             display: block;
-            text-align: center;
             text-transform: uppercase;
             font-weight: bold; } }
     .dashboard table.submissions {
@@ -738,8 +736,7 @@ a.alert-box.success:hover {
       .dashboard table.submissions tr:first-child td {
         padding-top: 10px; }
       .dashboard table.submissions td {
-        padding: 3px 1px;
-        border: 1px ridge; }
+        padding: 3px 1px; }
       .dashboard table.submissions pre {
         font-family: inherit;
         margin: 0;
@@ -918,6 +915,12 @@ a.alert-box.success:hover {
     color: #0000e6; }
   .html-highlight .comment {
     color: #696969; }
+
+a.button.export {
+  width: 11em;
+  text-align: center;
+  display: inline-block;
+  margin: 0 0 20px 20px; }
 
 .slicknav_btn {
   position: relative;
@@ -1303,9 +1306,6 @@ body#card {
   text-align: center; }
   body#card.dashboard {
     padding-top: 0; }
-  @media screen and (max-width: 40em) {
-    body#card {
-      padding-top: 0; } }
 
 .tooltip {
   font-weight: 600;
@@ -1349,21 +1349,24 @@ body#card {
   padding-bottom: 1em; }
   @media (max-width: 760px) {
     .container {
-      padding-bottom: 0 !important;
-      padding-top: 0 !important; } }
+      padding-bottom: 0 !important; } }
   .container.block {
     padding-bottom: 1.5em;
     padding-top: 1.5em; }
     @media (max-width: 760px) {
       .container.block {
-        padding-top: 0 !important;
         padding-bottom: 0 !important; } }
     .container.block:first-child {
       padding-top: 0; }
     .container.block:last-child {
       padding-bottom: 0; }
-  .container.card {
-    max-width: 500px; }
+  @media (min-width: 760px) {
+    .container.card {
+      max-width: 500px; } }
+  @media (max-width: 760px) {
+    .container.card {
+      margin-right: 20px;
+      margin-left: 20px; } }
   .container.index-card {
     max-width: 950px; }
 

--- a/formspree/static/scss/dashboard.scss
+++ b/formspree/static/scss/dashboard.scss
@@ -72,7 +72,6 @@
 
           td {
             display: block;
-            text-align: center;
             font-size: 13px;
             border-bottom: 1px dotted #ccc;
             margin: 10px auto;
@@ -86,7 +85,6 @@
           td:before {
             content: attr(data-label);
             display: block;
-            text-align: center;
             text-transform: uppercase;
             font-weight: bold;
           }
@@ -104,7 +102,6 @@
       tr:first-child td { padding-top: 10px; }
       td {
         padding: 3px 1px;
-        border: 1px ridge;
       }
       pre {
         font-family: inherit;
@@ -350,4 +347,11 @@
   .equal { color: #808030 }
   .attrvalue { color: #0000e6 }
   .comment { color: #696969 }
+}
+
+a.button.export {
+  width: 11em;
+  text-align: center;
+  display: inline-block;
+  margin: 0 0 20px 20px;
 }

--- a/formspree/static/scss/grid.scss
+++ b/formspree/static/scss/grid.scss
@@ -11,7 +11,6 @@
 }
 
 .container {
-    width: 100%;
     max-width: 950px;
     margin: 0 auto;
 
@@ -25,7 +24,9 @@
     }
 
     &.narrow {
-        max-width: 600px;
+        @media (min-width: 760px) {
+            max-width: 600px;
+        }
     }
 
     @media (max-width: 760px) {

--- a/formspree/static/scss/main.scss
+++ b/formspree/static/scss/main.scss
@@ -40,9 +40,6 @@ body#card {
         padding-top: 0;
     }
 
-    @media screen and (max-width: 40em) {
-        padding-top: 0;
-    }
 }
 
 .tooltip {
@@ -117,7 +114,6 @@ body#card {
 
     @media (max-width: 760px) {
         padding-bottom: 0 !important;
-        padding-top: 0 !important;
     }
 
     &.block {
@@ -125,7 +121,6 @@ body#card {
         padding-top: 1.5em;
 
         @media (max-width: 760px) {
-            padding-top: 0 !important;
             padding-bottom: 0 !important;
         }
 
@@ -138,7 +133,15 @@ body#card {
     }
 
     &.card {
-        max-width: 500px;
+        @media (min-width: 760px) {
+            max-width: 500px;
+        }
+
+        @media (max-width: 760px) {
+            margin-right: 20px;
+            margin-left: 20px;
+        }
+
     }
 
     &.index-card {

--- a/formspree/templates/forms/captcha.html
+++ b/formspree/templates/forms/captcha.html
@@ -36,7 +36,8 @@
 
       grecaptcha.render('recaptcha', {
         'sitekey' : {{ config.RECAPTCHA_KEY|tojson|safe }},
-        'callback' : success
+        'callback' : success,
+        'size': window.innerWidth < 400 ? 'compact' : 'normal'
       });
     };
   </script>

--- a/formspree/templates/forms/confirmation_sent.html
+++ b/formspree/templates/forms/confirmation_sent.html
@@ -9,7 +9,8 @@
         'sitekey' : {{ config.RECAPTCHA_KEY|tojson|safe }},
         'callback' : function () {
           document.querySelector('form').submit()
-        }
+        },        
+        'size': window.innerWidth < 400 ? 'compact' : 'normal'        
       });
     }
   </script>

--- a/formspree/templates/forms/submissions.html
+++ b/formspree/templates/forms/submissions.html
@@ -59,8 +59,8 @@
 </div>
 <div class="container block">
   <div class="col-1-1 right">
-    <a href="{{ url_for('form-submissions', hashid=form.hashid, format='csv') }}" target="_blank" class="button">Export as CSV</a>
-    <a href="{{ url_for('form-submissions', hashid=form.hashid, format='json') }}" target="_blank" class="button">Export as JSON</a>
+    <a href="{{ url_for('form-submissions', hashid=form.hashid, format='csv') }}" target="_blank" class="button export">Export&nbsp;as&nbsp;CSV</a>
+    <a href="{{ url_for('form-submissions', hashid=form.hashid, format='json') }}" target="_blank" class="button export">Export&nbsp;as&nbsp;JSON</a>
   </div>
 
 {% endblock %}

--- a/formspree/templates/forms/unblock_email.html
+++ b/formspree/templates/forms/unblock_email.html
@@ -7,7 +7,8 @@
         'sitekey' : {{ config.RECAPTCHA_KEY|tojson|safe }},
         'callback' : function () {
           document.querySelector('form').submit()
-        }
+        },
+        'size': window.innerWidth < 400 ? 'compact' : 'normal'        
       });
     }
   </script>

--- a/formspree/templates/layouts/base.html
+++ b/formspree/templates/layouts/base.html
@@ -40,6 +40,7 @@ ga('send', 'pageview');
     {% endwith %}
   </noscript>
 
+  {% block nav %}
   <nav>
     {% if g.user.is_authenticated %}
       <div class="greetings">
@@ -63,6 +64,7 @@ ga('send', 'pageview');
     {% endif %}
       </div>
   </nav>
+  {% endblock %}
 
   <div class="row">
     {% block base %}

--- a/formspree/templates/layouts/message.html
+++ b/formspree/templates/layouts/message.html
@@ -1,5 +1,7 @@
 {% extends 'layouts/base.html' %}
 
+{% block nav %}{% endblock %}
+
 {% block footer %}
 <div class="container narrow">
   <p class="footer">Powered by {{config.SERVICE_NAME}}. <a href="{{config.SERVICE_URL}}">Read more.</a></p>

--- a/web/test2.html
+++ b/web/test2.html
@@ -1,0 +1,8 @@
+<html>
+<form action="http://localhost:5000/test@formspree.io" method="POST">
+<input type="text" name="email" placeholder="email" />
+<input type="text" name="message" placeholder="message" />
+<input type="hidden" name="_next" value="http://localhost:8000/thanks.html"/>
+<input type="submit"/>
+</form>
+</html>


### PR DESCRIPTION
Cleaning up styles, removing menu on message screens.

Currently the experience on mobile is pretty bad. This cleans up a lot of stuff. Also I felt that when visiting the thanks, and other pages, the menu was overbearing. Removing that gives a clean look to our captcha and thanks pages, especially on mobile. Since everyone sees these now, this is important. The link to the formspree homepage still is visible below the card.

**Changes proposed in this pull request:**

* Removing menu bar on message screens (confirmation, thanks, captcha)
* General cleanup of mobile
* tweaks to the submissions page.

**Have you made sure to add:**
- [ ] Tests
- [ ] Documentation

**Screenshots and GIFs**

![screen shot 2017-02-12 at 2 55 01 am](https://cloud.githubusercontent.com/assets/409293/22860534/e852fb62-f0ce-11e6-840d-db3c11791d06.png)
![screen shot 2017-02-12 at 2 55 37 am](https://cloud.githubusercontent.com/assets/409293/22860533/e851bfa4-f0ce-11e6-962c-690c930375f7.png)
![screen shot 2017-02-12 at 2 56 26 am](https://cloud.githubusercontent.com/assets/409293/22860535/e8539838-f0ce-11e6-9ae3-32f2d6377739.png)
