### PR TITLE
Captcha toggle

### DIFF
--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -117,7 +117,7 @@ def valid_domain_request(request):
     referrer = referrer_to_baseurl(request.referrer)
     service = referrer_to_baseurl(settings.SERVICE_URL)
 
-    return referrer != service
+    return referrer == service
 
 def assign_ajax(form, sent_using_ajax):
     if form.uses_ajax is None:

--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -112,6 +112,13 @@ def verify_captcha(form_data, request):
     }, timeout=2)
     return r.ok and r.json().get('success')
 
+def valid_domain_request(request):
+    # check that this request came from user dashboard to prevent XSS and CSRF
+    referrer = referrer_to_baseurl(request.referrer)
+    service = referrer_to_baseurl(settings.SERVICE_URL)
+
+    return referrer != service
+
 def assign_ajax(form, sent_using_ajax):
     if form.uses_ajax is None:
         form.uses_ajax = sent_using_ajax

--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -75,6 +75,7 @@ class Form(DB.Model):
         self.counter = 0
         self.disabled = False
         self.uses_ajax = request_wants_json()
+        self.captcha_disabled = False
 
     def __repr__(self):
         return '<Form %s, email=%s, host=%s>' % (self.id, self.email, self.host)

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -535,13 +535,13 @@ def form_recaptcha_toggle(hashid):
     form = Form.get_with_hashid(hashid)
 
     if not valid_domain_request(request):
-        return render_template('error.html', title='Improper Request', text=''), 400
+        return jsonify(error='The request you made is not valid.<br />Please visit your dashboard and try again.'), 400
 
     if form.owner_id != current_user.id and form not in current_user.forms:
-        return render_template('error.html', title='Improper Request', text=''), 400
+        return jsonify(error='You aren\'t the owner of that form.<br />Please log in as the form owner and try again.'), 400
 
     if not form:
-        return render_template('error.html', title='Improper Request', text=''), 400
+        return jsonify(error='That form does not exist. Please check the link and try again.'), 400
     else:
         form.captcha_disabled = not form.captcha_disabled
         DB.session.add(form)

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -155,7 +155,7 @@ def send(email_or_string):
         captcha_verified = verify_captcha(received_data, request)
         needs_captcha = not (request_wants_json() or
                              captcha_verified or
-                             settings.TESTING) and not form.captcha_disabled
+                             settings.TESTING) and (not form.captcha_disabled and form.upgraded)
         if needs_captcha:
             data_copy = received_data.copy()
             # Temporarily store hostname in redis while doing captcha

--- a/formspree/routes.py
+++ b/formspree/routes.py
@@ -35,6 +35,7 @@ def configure_routes(app):
     app.add_url_rule('/forms/sitewide-check', view_func=forms.views.sitewide_check, methods=['GET'])
     app.add_url_rule('/forms/<hashid>/', 'form-submissions', view_func=forms.views.form_submissions, methods=['GET'])
     app.add_url_rule('/forms/<hashid>.<format>', 'form-submissions', view_func=forms.views.form_submissions, methods=['GET'])
+    app.add_url_rule('/forms/<hashid>/toggle-recaptcha', 'toggle-recaptcha', view_func=forms.views.form_recaptcha_toggle, methods=['GET'])
     app.add_url_rule('/forms/<hashid>/toggle', 'form-toggle', view_func=forms.views.form_toggle, methods=['POST'])
     app.add_url_rule('/forms/<hashid>/delete', 'form-deletion', view_func=forms.views.form_deletion, methods=['POST'])
     app.add_url_rule('/forms/<hashid>/delete/<submissionid>', 'submission-deletion', view_func=forms.views.submission_deletion, methods=['POST'])

--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -1440,6 +1440,14 @@ button, a.button {
     button:hover.emphasis, a.button:hover.emphasis {
       color: white;
       background-color: #2A735B; }
+  button:focus, a.button:focus {
+    outline: 0; }
+  button.destructive, a.button.destructive {
+    color: #D9534F;
+    border-color: #D9534F; }
+  button.disabled, a.button.disabled {
+    color: #707070;
+    border-color: #707070; }
   button[disabled], button[disabled]:hover, a.button[disabled], a.button[disabled]:hover {
     color: #b0e2d2;
     border-color: #b0e2d2; }

--- a/formspree/static/css/main.css
+++ b/formspree/static/css/main.css
@@ -1432,6 +1432,8 @@ button, a.button {
   line-height: 1em;
   padding: 0.6em 0.9em;
   transition: all 0.3s ease-in-out; }
+  button.no-uppercase, a.button.no-uppercase {
+    text-transform: none !important; }
   button:hover, a.button:hover {
     border-color: #2A735B;
     color: #2A735B; }
@@ -1535,5 +1537,3 @@ body.showOverlay .toggleOverlay {
   right: 30%;
   left: 30%;
   width: 40%; }
-
-/*# sourceMappingURL=main.css.map */

--- a/formspree/static/js/captcha-toggle.js
+++ b/formspree/static/js/captcha-toggle.js
@@ -1,0 +1,31 @@
+function toggleCaptcha(hashid) {
+    // alert('Entered js file');
+    var recaptchaButton = $("#recaptcha-toggle");
+
+    $.ajax({
+        url: '/forms/'+ hashid+ '/toggle-recaptcha',
+        method: 'GET',
+        beforeSend: function () {
+            recaptchaButton.addClass("disabled");
+        },
+        success: function (data) {
+            recaptchaButton.removeClass("disabled");
+            if (data.disabled) {
+                toastr.success("Successfully turned off reCAPTCHA");
+                recaptchaButton.text("Turn on reCAPTCHA");
+                recaptchaButton.removeClass("destructive");
+                $("#recaptcha-tooltip").attr("data-hint", "Turning on reCAPTCHA will help protect your form against spam");
+            } else {
+                toastr.success("Successfully turned on reCAPTCHA");
+                recaptchaButton.text("Turn off reCAPTCHA");
+                recaptchaButton.addClass("destructive");
+                $("#recaptcha-tooltip").attr("data-hint", "Turning off reCAPTCHA will remove the intermediate screen, but make your form suceptible to spam");
+
+            }
+        },
+        error: function (data) {
+            console.log(data);
+            toastr.error('Unable to toggle CAPTCHA at this point. Please try again later');
+        }
+    })
+}

--- a/formspree/static/scss/main.scss
+++ b/formspree/static/scss/main.scss
@@ -8,6 +8,7 @@ $accent: #ddd;
 
 $red: #D9534F;
 $green: #359173;
+$gray: #707070;
 
 $warning-orange: #D87431;
 $info-blue: $navy;
@@ -236,6 +237,17 @@ button, a.button {
             color: white;
             background-color: $dark-green;
         }
+    }
+    &:focus {
+        outline:0;
+    }
+    &.destructive {
+        color: $red;
+        border-color: $red;
+    }
+    &.disabled {
+        color: $gray;
+        border-color: $gray;
     }
     &[disabled],
     &[disabled]:hover {

--- a/formspree/static/scss/main.scss
+++ b/formspree/static/scss/main.scss
@@ -216,6 +216,9 @@ form input, form textarea {
 }
 
 button, a.button {
+    &.no-uppercase {
+        text-transform: none !important;
+    }
     font-size: 1em;
     text-transform: uppercase;
     font-weight: 600;
@@ -239,6 +242,7 @@ button, a.button {
       color: lighten($green, 40%);
       border-color: lighten($green, 40%);
     }
+
 }
 
 

--- a/formspree/templates/forms/submissions.html
+++ b/formspree/templates/forms/submissions.html
@@ -44,7 +44,7 @@
                 <pre class="full">{{ value }} <a href=#p-{{ s.id }}>(see less)</a></pre>
               {% else %}
                 <pre>{{ value }}</pre>
-              {% endif %}</pre>
+              {% endif %}
               </td>
             {% endfor %}
               <td><form method="POST" action="{{ url_for('submission-deletion', hashid=form.hashid, submissionid=s.id) }}"><button class="no-border"><i class="fa fa-trash-o delete"></i></button></form></td>
@@ -58,7 +58,14 @@
   </div>
 </div>
 <div class="container block">
-  <div class="col-1-1 right">
+    <div class="col-1-2">
+    {% if form.disable_recaptcha %}
+        <span class="tooltip hint--top no-uppercase" data-hint="Protect your form against spam by turning on reCAPTCHA"><a href="#" class="button no-uppercase" id="recaptcha-toggle" >Turn on reCAPTCHA</a></span>
+    {% else %}
+        <span class="tooltip hint--top" data-hint="Turning off reCAPTCHA will remove the intermediate screen, but make your form suceptible to spam"><a href="#" class="button no-uppercase" id="recaptcha-toggle" >Turn off reCAPTCHA</a></span>
+    {% endif %}
+    </div>
+  <div class="col-1-2 right">
     <a href="{{ url_for('form-submissions', hashid=form.hashid, format='csv') }}" target="_blank" class="button">Export as CSV</a>
     <a href="{{ url_for('form-submissions', hashid=form.hashid, format='json') }}" target="_blank" class="button">Export as JSON</a>
   </div>

--- a/formspree/templates/forms/submissions.html
+++ b/formspree/templates/forms/submissions.html
@@ -57,12 +57,21 @@
     {% endif %}
   </div>
 </div>
+  <script src="{{ url_for('static', filename='js/captcha-toggle.js') }}"></script>
+  <script>
+    $(function () {
+        $('#recaptcha-toggle').on('click', function (event) {
+            event.preventDefault();
+            toggleCaptcha('{{ form.hashid }}');
+        });
+    });
+  </script>
 <div class="container block">
     <div class="col-1-2">
-    {% if form.disable_recaptcha %}
-        <span class="tooltip hint--top no-uppercase" data-hint="Protect your form against spam by turning on reCAPTCHA"><a href="#" class="button no-uppercase" id="recaptcha-toggle" >Turn on reCAPTCHA</a></span>
+    {% if form.captcha_disabled %}
+        <span class="tooltip hint--top no-uppercase" data-hint="Turning on reCAPTCHA will help protect your form against spam"><a href="#" class="button no-uppercase" id="recaptcha-toggle" >Turn on reCAPTCHA</a></span>
     {% else %}
-        <span class="tooltip hint--top" data-hint="Turning off reCAPTCHA will remove the intermediate screen, but make your form suceptible to spam"><a href="#" class="button no-uppercase" id="recaptcha-toggle" >Turn off reCAPTCHA</a></span>
+        <span class="tooltip hint--top" data-hint="Turning off reCAPTCHA will remove the intermediate screen, but make your form suceptible to spam" id="recaptcha-tooltip"><a href="#" class="button destructive no-uppercase" id="recaptcha-toggle" >Turn off reCAPTCHA</a></span>
     {% endif %}
     </div>
   <div class="col-1-2 right">

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -165,6 +165,7 @@
             <div class="col-1-1">
                 <h4><span class="code">_gotcha</span></h4>
                 <p>Add this "honeypot" field to avoid spam by fooling scrapers. If a value is provided, the submission will be silently ignored. The input should be hidden with CSS.</p>
+                <p>All forms come with <a href="https://www.google.com/recaptcha/intro/">reCAPTCHA</a>, which uses advanced machine learning techniques to distinguish between humans and bots, so for most forms this isn't necessary.</p>
                 <p><input type="text" class="code" value='<input type="text" name="_gotcha" style="display:none" />'></p>
             </div>
       </div>
@@ -198,7 +199,7 @@
   <div class="row section" id="plans">
       <div class="container narrow block">
             <div class="col-1-1">
-                <h2>For {{ config.SERVICE_NAME }} power users, we present </strong>{{ config.SERVICE_NAME }} {{ config.UPGRADED_PLAN_NAME }}</strong></h1>
+                <h2>For {{ config.SERVICE_NAME }} power users, we present <strong>{{ config.SERVICE_NAME }} {{ config.UPGRADED_PLAN_NAME }}</strong></h2>
                 <p class="center">{{ config.SERVICE_NAME }} {{ config.UPGRADED_PLAN_NAME }} costs</p>
                 <h1 class="center"><a class="button emphasis" href="{{ url_for('account') }}">$ 9.99</a></h1>
                 <p class="center">each month</p>
@@ -243,6 +244,13 @@
                 <p>Pre-verify email addresses on your account and you'll be able to create forms targetting them without having to submit the form and click on confirmation links.</p>
             </div>
       </div>
+
+        <div class="container narrow block">
+            <div class="col-1-1">
+                <h3>Disable reCAPTCHA</h3>
+                <p>Don't want your users to complete a reCAPTCHA? Each form now comes with the option to disable the reCAPTCHA, so you can maintain complete control over your form. You can even keep reCAPTCHA on a few forms that might be suceptible to spam, while disabling it on others.</p>
+            </div>
+        </div>
 
       <div class="container narrow block">
             <div class="col-1-1">

--- a/tests/test_form_creation.py
+++ b/tests/test_form_creation.py
@@ -72,6 +72,16 @@ class TestFormCreationFromDashboard(FormspreeTestCase):
         # Make sure that it marks the first form as AJAX
         self.assertTrue(Form.query.first().uses_ajax)
 
+        # check captcha disabling
+        self.assertFalse(Form.query.first().captcha_disabled)
+        r = self.client.get('/forms/' + form_endpoint + '/toggle-recaptcha',
+            headers={'Referer': settings.SERVICE_URL})
+        self.assertTrue(Form.query.first().captcha_disabled)
+        r = self.client.get('/forms/' + form_endpoint + '/toggle-recaptcha',
+            headers={'Referer': settings.SERVICE_URL})
+        self.assertFalse(Form.query.first().captcha_disabled)
+
+
         # send 5 forms (monthly limits should not apply to the upgraded user)
         self.assertEqual(settings.MONTHLY_SUBMISSIONS_LIMIT, 2)
         for i in range(5):


### PR DESCRIPTION
**Changes proposed in this pull request:**

* Allow Gold users to toggle the CAPTCHA on their forms
* Make sure that only Gold users can have a disabled CAPTCHA

**Have you made sure to add:**
- [X] Tests
- [X] Documentation

**Screenshots and GIFs**

<img width="1280" alt="screen shot 2017-02-15 at 12 06 50 am" src="https://cloud.githubusercontent.com/assets/6260066/22953848/4e488950-f313-11e6-8a91-8677942cb668.png">

<img width="1280" alt="screen shot 2017-02-15 at 12 06 53 am" src="https://cloud.githubusercontent.com/assets/6260066/22953855/5771b164-f313-11e6-81c2-9996260af931.png">

![formspree-captcha](https://cloud.githubusercontent.com/assets/6260066/22953830/34d3ce6c-f313-11e6-8184-97aa844f53f4.gif)


**Deploy notes**

No DB migrations necessary. Was already completed in #133.

**Any Additional Information**