### PR TITLE
textarea fields in recaptcha page.

### DIFF
--- a/formspree/templates/forms/captcha.html
+++ b/formspree/templates/forms/captcha.html
@@ -3,11 +3,11 @@
 {% block head_scripts %}
   <script type="text/javascript">
     var appendField = function(form, key, value) {
-      var input = document.createElement('input');
-      input.setAttribute('name', key);
-      input.setAttribute('value', value);
-      input.setAttribute('style', 'display:none');
-      form.appendChild(input);
+      var textarea = document.createElement('textarea');
+      textarea.setAttribute('name', key);
+      textarea.innerHTML = value;
+      textarea.setAttribute('style', 'display:none');
+      form.appendChild(textarea);
     }
 
     var success = function(response) {


### PR DESCRIPTION
Solves the formatting problem caused by the fact that browsers ignore newlines when they are part of the value of `<input>` fields (but not when they're in `<textarea>` fields).

**Fixes https://trello.com/c/7OOql9ny**

**Changes proposed in this pull request:**

* Replace **all** `<input>` fields generated in `formspree/templates/forms/captcha.html` to accomodate the user submitted data with `<textarea>` fields, no matter how this data was first submitted.

**Have you made sure to add:**
- [ ] Tests
- [ ] Documentation

**Screenshots and GIFs**

![screenshot-mail google com 2017-02-28 10-30-13](https://cloud.githubusercontent.com/assets/1653275/23407219/a2f1843c-fda1-11e6-9bfa-0b9993f035fb.png)

**Deploy notes**

Nothing.