### PR TITLE
Fixed url routing for resubscription

### DIFF
--- a/formspree/routes.py
+++ b/formspree/routes.py
@@ -18,6 +18,7 @@ def configure_routes(app):
     app.add_url_rule('/account', 'account', view_func=users.views.account, methods=['GET'])
     app.add_url_rule('/account/upgrade', view_func=users.views.upgrade, methods=['POST'])
     app.add_url_rule('/account/downgrade', view_func=users.views.downgrade, methods=['POST'])
+    app.add_url_rule('/account/resubscribe', view_func=users.views.resubscribe, methods=['POST'])
     app.add_url_rule('/card/add', 'add-card', view_func=users.views.add_card, methods=['POST'])
     app.add_url_rule('/card/<cardid>/delete', 'delete-card', view_func=users.views.delete_card, methods=['POST'])
     app.add_url_rule('/account/add-email', 'add-account-email', view_func=users.views.add_email, methods=['POST'])

--- a/formspree/templates/users/account.html
+++ b/formspree/templates/users/account.html
@@ -47,7 +47,7 @@
           <p>You are a {{ config.SERVICE_NAME }} {{ config.UPGRADED_PLAN_NAME }} user.</p>
           {% if sub.cancel_at_period_end %}
             <p>You've cancelled your subscription and it is ending on {{ sub.current_period_end }}.</p>
-            <form action="/account/upgrade" method="POST">
+            <form action="/account/resubscribe" method="POST">
               <button type="submit">Resubscribe</button>
             </form>
           {% else %}


### PR DESCRIPTION
**Fixes resubscription not working.**

**Changes proposed in this pull request:**

* Resubscription button was pointing to wrong URL route

**Have you made sure to add:**
- [ ] Tests
- [ ] Documentation

**Deploy notes**

None necessary. Simple but important fix.

**Any Additional Information**