### PR TITLE
store first submission on redis, send it on confirmation.

### DIFF
--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -174,7 +174,7 @@ def send(email_or_string):
 
         status = form.send(received_data, sorted_keys, referrer)
     else:
-        status = form.send_confirmation()
+        status = form.send_confirmation(store_data=received_data)
 
     # Respond to the request accordingly to the status code
     if status['code'] == Form.STATUS_EMAIL_SENT:


### PR DESCRIPTION
This is a possible way to solve the problems of users who set up Formspree and forget to test them (because they are already familiar with Formspree, probably) and end up missing their first submission. I've done that myself, we've experimented it with Formspree's own forms. It's a problem.

This PR just introduces code that saves the data, unordered, unfiltered, on Redis upon the first submission -- only the first -- of a form that would trigger sending an email confirmation. The data on Redis is set to expire in some days.

When the form is confirmed, that data is just fetched and emailed just like a normal form submission would be.