### PR TITLE
Store data in session storage for reloading page

### DIFF
--- a/formspree/templates/forms/captcha.html
+++ b/formspree/templates/forms/captcha.html
@@ -21,10 +21,10 @@
       var form = document.querySelector('#passthrough');
       var data;
       if (sessionStorage.getItem("data")) {
-          data = sessionStorage.getItem("data");
+          data = JSON.parse(sessionStorage.getItem("data"));
       } else {
           data = {{ data|tojson|safe }};
-          sessionStorage.setItem("data", data);
+          sessionStorage.setItem("data", JSON.stringify(data));
       }
       var keys = {{ sorted_keys|tojson|safe }};
       for (var i = 0; i < keys.length; i++) {

--- a/formspree/templates/forms/captcha.html
+++ b/formspree/templates/forms/captcha.html
@@ -13,6 +13,9 @@
     var success = function(response) {
       var form = document.querySelector('#passthrough');
 
+      //remove data from session storage
+      sessionStorage.removeItem("data");
+
       //handles the case where user has a button named 'submit'
       document.createElement('form').submit.call(form);
     };

--- a/formspree/templates/forms/captcha.html
+++ b/formspree/templates/forms/captcha.html
@@ -8,7 +8,7 @@
       textarea.innerHTML = value;
       textarea.setAttribute('style', 'display:none');
       form.appendChild(textarea);
-    }
+    };
 
     var success = function(response) {
       var form = document.querySelector('#passthrough');
@@ -19,10 +19,16 @@
 
     var onloadCallback = function() {
       var form = document.querySelector('#passthrough');
-      var data = {{ data|tojson|safe }};
+      var data;
+      if (sessionStorage.getItem("data")) {
+          data = sessionStorage.getItem("data");
+      } else {
+          data = {{ data|tojson|safe }};
+          sessionStorage.setItem("data", data);
+      }
       var keys = {{ sorted_keys|tojson|safe }};
       for (var i = 0; i < keys.length; i++) {
-        var key = keys[i]
+        var key = keys[i];
         if (data.hasOwnProperty(key)) {
           appendField(form, key, data[key])
           delete data[key];

--- a/formspree/templates/forms/captcha.html
+++ b/formspree/templates/forms/captcha.html
@@ -22,11 +22,14 @@
 
     var onloadCallback = function() {
       var form = document.querySelector('#passthrough');
-      var data;
+      var data = {{ data|tojson|safe }};
       if (sessionStorage.getItem("data")) {
-          data = JSON.parse(sessionStorage.getItem("data"));
+          if (Object.keys(data).length > 1) { //if data is valid overwrite current storage
+              sessionStorage.setItem("data", JSON.stringify(data));
+          } else { //passed in blank data except host_nonce
+              data = JSON.parse(sessionStorage.getItem("data"));
+          }
       } else {
-          data = {{ data|tojson|safe }};
           sessionStorage.setItem("data", JSON.stringify(data));
       }
       var keys = {{ sorted_keys|tojson|safe }};


### PR DESCRIPTION
**Fixes error when reloading reCAPTCHA page.**

**Changes proposed in this pull request:**

* Store the data in session storage on reCAPTCHA page to prevent empty data.

**Have you made sure to add:**
- [X] Tests
- [ ] Documentation

**Screenshots and GIFs**

None.

**Deploy notes**

None necessary.

**Any Additional Information**
Currently, if the user has the HSTS policy set on their browser, if they submit to the HTTP version of Formspree and reload the reCAPTCHA page, it loses the data. A very niche scenario, but operating under the assumption that the HSTS is set for our users, this will store the data in [session storage](https://developer.mozilla.org/en/docs/Web/API/Window/sessionStorage). Upon loading, it will check if data exists in session storage. Right before submitting, it will remove the data from session storage.