### PR TITLE
Captcha internationalization

### DIFF
--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -15,7 +15,7 @@ CAPTCHA_URL = 'https://www.google.com/recaptcha/api/siteverify'
 CAPTCHA_VAL = 'g-recaptcha-response'
 
 HASH = lambda x, y: hashlib.md5(x.encode('utf-8')+y.encode('utf-8')+settings.NONCE_SECRET).hexdigest()
-EXCLUDE_KEYS = {'_gotcha', '_next', '_subject', '_cc', '_format', CAPTCHA_VAL, '_host_nonce'}
+EXCLUDE_KEYS = {'_gotcha', '_next', '_subject', '_cc', '_format', CAPTCHA_VAL, '_host_nonce', '_language'}
 REDIS_COUNTER_KEY = 'monthly_{form_id}_{month}'.format
 REDIS_HOSTNAME_KEY = 'hostname_{nonce}'.format
 REDIS_FIRSTSUBMISSION_KEY = 'first_{nonce}'.format

--- a/formspree/templates/forms/captcha.html
+++ b/formspree/templates/forms/captcha.html
@@ -65,8 +65,10 @@
 
     <div class="container">
       <div class="col-1-1">
-        <h1>Almost there</h1>
-        <p>Please help us fight spam by following the directions below:</p>
+        {% block instructions %}
+          <h1>Almost there</h1>
+          <p>Please help us fight spam by following the directions below:</p>
+        {% endblock %}
 
         <form action="{{ action }}" method="POST" id="passthrough">
           <div id="recaptcha" style="text-align:center; display:inline-block"></div>

--- a/formspree/templates/forms/captcha_lang/en.html
+++ b/formspree/templates/forms/captcha_lang/en.html
@@ -1,0 +1,5 @@
+{% extends 'forms/captcha.html' %}
+{% block instructions %}
+  <h1>Almost there</h1>
+  <p>Please help us fight spam by following the directions below:</p>
+{% endblock %}

--- a/formspree/templates/forms/captcha_lang/es.html
+++ b/formspree/templates/forms/captcha_lang/es.html
@@ -1,5 +1,5 @@
 {% extends 'forms/captcha.html' %}
 {% block instructions %}
   <h1>Solo un paso más!</h1>
-  <p>Por favor, ayúdenos a combatir el spam siguiendo las instrucciones a continuación</p>
+  <p>Por favor, ayúdenos a combatir el spam siguiendo las instrucciones a continuación:</p>
 {% endblock %}

--- a/formspree/templates/forms/captcha_lang/es.html
+++ b/formspree/templates/forms/captcha_lang/es.html
@@ -1,0 +1,5 @@
+{% extends 'forms/captcha.html' %}
+{% block instructions %}
+  <h1>Solo un paso más!</h1>
+  <p>Por favor, ayúdenos a combatir el spam siguiendo las instrucciones a continuación</p>
+{% endblock %}

--- a/formspree/templates/forms/captcha_lang/pt.html
+++ b/formspree/templates/forms/captcha_lang/pt.html
@@ -1,0 +1,5 @@
+{% extends 'forms/captcha.html' %}
+{% block instructions %}
+  <h1>Estamos quase lá!</h1>
+  <p>Por favor, siga as instruções a seguir para ajudar-nos a combater o spam:</p>
+{% endblock %}

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -164,7 +164,7 @@
     <div class="container narrow block">
             <div class="col-1-1">
                 <h4><span class="code">_language</span></h4>
-              <p>We've gone global! If you want to display the reCAPTCHA page in a language other than English you can. We currently only support <span class="code">en</span> and <span class="code">es</span>.</p>
+              <p>We've gone global! If you want to display the reCAPTCHA page in a language other than English you can. We currently only support <span class="code">en</span>, <span class="code">es</span>, and <span class="code">pt</span>.</p>
               <p>We love adding new languages! We're no language experts, but if you want your language added, please <a href="https://help.formspree.io/contact">let us know</a>.</p>
                 <p><input type="text" class="code" value='<input type="hidden" name="_language" value="es" />'></p>
 

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -161,6 +161,16 @@
             </div>
       </div>
 
+    <div class="container narrow block">
+            <div class="col-1-1">
+                <h4><span class="code">_language</span></h4>
+              <p>We've gone global! If you want to display the reCAPTCHA page in a language other than English you can. We currently only support <span class="code">en</span> and <span class="code">es</span>.</p>
+              <p>We love adding new languages! We're no language experts, but if you want your language added, please <a href="https://help.formspree.io/contact">let us know</a>.</p>
+                <p><input type="text" class="code" value='<input type="hidden" name="_language" value="es" />'></p>
+
+            </div>
+      </div>
+
       <div class="container narrow block">
             <div class="col-1-1">
                 <h4><span class="code">_gotcha</span></h4>


### PR DESCRIPTION
**Fixes internationalization issues.**

**Changes proposed in this pull request:**

* Add Spanish as a supported language for reCAPTCHA using _language variable

**Have you made sure to add:**
- [ ] Tests
- [X] Documentation

**Screenshots and GIFs**

<img width="1280" alt="screen shot 2017-05-26 at 7 37 55 pm" src="https://cloud.githubusercontent.com/assets/6260066/26505921/dd137952-424a-11e7-9ee0-86143119079f.png">

**Deploy notes**

None necessary.

**Any Additional Information**
Address user complaints about displaying Formspree reCAPTCHA in their native language. Very simple and easy to add new languages.