### PR TITLE
ignore ending slashes for forms created in the dashboard.

### DIFF
--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -95,11 +95,7 @@ def send(email_or_string):
 
             if not form.host:
                 # add the host to the form
-                form.host = host.rstrip('/') # we can remove ending slashes here because this
-                                             # form was surely created in the dashboard and
-                                             # doesn't have a hash.
-                form.host = remove_www(forms.host) # the same principle applies to
-                                                   # 'www.' prefixes.
+                form.host = host
                 DB.session.add(form)
                 DB.session.commit()
 

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -98,6 +98,8 @@ def send(email_or_string):
                 form.host = host.rstrip('/') # we can remove ending slashes here because this
                                              # form was surely created in the dashboard and
                                              # doesn't have a hash.
+                form.host = remove_www(forms.host) # the same principle applies to
+                                                   # 'www.' prefixes.
                 DB.session.add(form)
                 DB.session.commit()
 
@@ -107,10 +109,10 @@ def send(email_or_string):
             elif (not form.sitewide and
                   # ending slashes can be safely ignored here:
                   form.host.rstrip('/') != host.rstrip('/')) or \
-                 (form.sitewide and (
-                   not host.startswith(form.host) and
-                   not remove_www(host).startswith(form.host)
-                 )):
+                 (form.sitewide and \
+                  # removing www from both sides makes this a neutral operation:
+                  not remove_www(host).startswith(remove_www(form.host))
+                 ):
                 g.log.info('Submission rejected. From a different host than confirmed.')
                 if request_wants_json():
                     return jsonerror(403, {

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -95,19 +95,22 @@ def send(email_or_string):
 
             if not form.host:
                 # add the host to the form
-                form.host = host
+                form.host = host.rstrip('/') # we can remove ending slashes here because this
+                                             # form was surely created in the dashboard and
+                                             # doesn't have a hash.
                 DB.session.add(form)
                 DB.session.commit()
 
                 # it is an error when
-                #   form is sitewide, but submission came from a host rooted somewhere else, or
                 #   form is not sitewide, and submission came from a different host
-            elif (not form.sitewide and form.host != host) or (
-                   form.sitewide and (
-                     not host.startswith(form.host) and \
-                     not remove_www(host).startswith(form.host)
-                   )
-                 ):
+                #   form is sitewide, but submission came from a host rooted somewhere else, or
+            elif (not form.sitewide and
+                  # ending slashes can be safely ignored here:
+                  form.host.rstrip('/') != host.rstrip('/')) or \
+                 (form.sitewide and (
+                   not host.startswith(form.host) and
+                   not remove_www(host).startswith(form.host)
+                 )):
                 g.log.info('Submission rejected. From a different host than confirmed.')
                 if request_wants_json():
                     return jsonerror(403, {


### PR DESCRIPTION
**Fixes https://formspree.zendesk.com/agent/tickets/5**

**Changes proposed in this pull request:**

* Discard ending slashes when setting and when comparing stored `.host` values with the host that has actually submitted the form. Since forms created through the dashboard have an id and the submission is identified by it (and not by the host/referrer value) this is safe. The value of `.host` in this case is only used for validation -- while in forms created automatically it is used for identification.

**Have you made sure to add:**
- [ ] Tests
- [ ] Documentation

**Deploy notes**

Nothing.