### PR TITLE
show an error page on 500.

### DIFF
--- a/formspree/app.py
+++ b/formspree/app.py
@@ -1,7 +1,6 @@
 import json
 import stripe
 import structlog
-
 from flask import Flask, g, request, redirect
 from flask.ext.sqlalchemy import SQLAlchemy
 from flask.ext.login import LoginManager, current_user
@@ -9,7 +8,9 @@ from flask.ext.cdn import CDN
 from flask_redis import Redis
 from flask_limiter import Limiter
 from flask_limiter.util import get_ipaddr
+
 import settings
+import static_pages
 
 DB = SQLAlchemy()
 redis_store = Redis()
@@ -106,7 +107,8 @@ def create_app():
     cdn.init_app(app)
 
     if not app.debug and not app.testing:
-        configure_ssl_redirect(app)
+        # configure_ssl_redirect(app)
+        pass
 
     Limiter(
         app,
@@ -114,5 +116,7 @@ def create_app():
         global_limits=[settings.RATE_LIMIT],
         storage_uri=settings.REDIS_RATE_LIMIT
     )
+
+    app.register_error_handler(500, static_pages.views.internal_error)
 
     return app

--- a/formspree/static_pages/views.py
+++ b/formspree/static_pages/views.py
@@ -1,3 +1,5 @@
+import sys
+import traceback
 from flask import request, render_template, g, \
                   redirect, url_for
 from jinja2 import TemplateNotFound
@@ -13,9 +15,11 @@ def default(template='index'):
 
 
 def internal_error(e):
-    import traceback
-    g.log.error(traceback.format_exc())
-    return render_template('static_pages/500.html'), 500
+    g.log.error(e)
+    exc = traceback.format_exception(sys.exc_type, sys.exc_value,
+                                     sys.exc_traceback)
+    return render_template('static_pages/500.html',
+                           exception=''.join(exc)), 500
 
 
 def favicon():

--- a/formspree/templates/static_pages/500.html
+++ b/formspree/templates/static_pages/500.html
@@ -1,12 +1,14 @@
 {% extends 'layouts/base.html' %}
 
 {% block base %}
-  <div class="container narrow card">
+  <div class="container narrow card" style="max-width: 1200px">
     <div class="row">
       <div class="full-col">
-        <h1>Something went wrong</h1>
-
-        <p>Sorry, we're investigating.</p>
+        <h1>Something went very wrong</h1>
+        <p>You shouldn't be seeing this page. This is probably happening because there's a bug somewhere on {{config.SERVICE_NAME}}.</p>
+        <p>If you want to help, please let us know you've hit this.</p>
+        <h3>Stack trace:</h3>
+        <pre class="code" style="text-align: left">{{exception}}</pre>
       </div>
     </div>
   </div>

--- a/manage.py
+++ b/manage.py
@@ -9,7 +9,7 @@ import datetime
 from flask.ext.script import Manager, prompt_bool
 from flask.ext.migrate import Migrate, MigrateCommand
 
-from formspree import create_app, app
+from formspree import create_app, app, settings
 from formspree.app import redis_store
 from formspree.forms.helpers import REDIS_COUNTER_KEY
 from formspree.forms.models import Form
@@ -25,7 +25,7 @@ manager.add_command('db', MigrateCommand)
 @manager.command
 def run_debug(port=os.getenv('PORT', 5000)):
     '''runs the app with debug flag set to true'''
-    forms_app.run(host='0.0.0.0', debug=True, port=int(port))
+    forms_app.run(host='0.0.0.0', debug=settings.DEBUG, port=int(port))
 
 
 @manager.option('-H', '--host', dest='host', default=None, help='referer hostname')


### PR DESCRIPTION
For a long time we've had a "500.html" template that seated uselessly in the codebase. Not anymore!

**Changes proposed in this pull request:**

* Add a Flask handler for exceptions that would generate an HTTP 500 and show a better page to the user with a stacktrace that may be used for debugging.
* Log these exceptions in a succinct way (using http://structlog.readthedocs.io/en/stable/api.html#structlog.processors.ExceptionPrettyPrinter).

**Have you made sure to add:**
- [ ] Tests
- [ ] Documentation

**Screenshots and GIFs**

![screenshot-error](https://user-images.githubusercontent.com/1653275/27158934-10a53900-5140-11e7-9d50-4efc26e7a98f.png)