### PR TITLE
Portuguese text fixes (semantics)

### DIFF
--- a/formspree/templates/forms/captcha_lang/pt.html
+++ b/formspree/templates/forms/captcha_lang/pt.html
@@ -1,5 +1,5 @@
 {% extends 'forms/captcha.html' %}
 {% block instructions %}
   <h1>Estamos quase lá!</h1>
-  <p>Por favor, siga as instruções a seguir para ajudar-nos a combater o spam:</p>
+  <p>Por favor siga as instruções seguintes para nos ajudar a combater o spam:</p>
 {% endblock %}


### PR DESCRIPTION
The Portuguese text was unclear and technically incorrect in pt-pt.
This is the correct form.

**1.**

**Changes proposed in this pull request:**

Changes to formspree/templates/forms/captcha_lang/pt.html

"Por favor, siga as instruções a seguir para ajudar-nos a combater o spam:"
To "Por favor siga as instruções seguintes para nos ajudar a combater o spam:"

**Have you made sure to add:**
- [x] Tests
- [x] Documentation
