### PR TITLE
Gmail Action for confirm emails.

### DIFF
--- a/formspree/templates/email/confirm.html
+++ b/formspree/templates/email/confirm.html
@@ -4,6 +4,21 @@
     <meta name="viewport" content="width=device-width" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title>Confirm Form</title>
+    <script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ConfirmAction",
+    "name": "Approve Expense",
+    "handler": {
+      "@type": "HttpActionHandler",
+      "url": "{{ nonce_link }}"
+    }
+  },
+  "description": "Confirm form on {{ host }}"
+}
+    </script>
 </head>
   <body itemscope="" itemtype="http://schema.org/EmailMessage" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #FFF; margin: 0; padding: 0;" bgcolor="#FFF">
     <table class="body-wrap" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; background-color: #FFF; margin: 0;" bgcolor="#FFF">

--- a/formspree/templates/email/pre_inline_style/confirm.html
+++ b/formspree/templates/email/pre_inline_style/confirm.html
@@ -5,6 +5,21 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title>Confirm Form</title>
     <link href="email_styles.css" media="all" rel="stylesheet" type="text/css" />
+    <script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ConfirmAction",
+    "name": "Approve Expense",
+    "handler": {
+      "@type": "HttpActionHandler",
+      "url": "{{ nonce_link }}"
+    }
+  },
+  "description": "Confirm form on {{ host }}"
+}
+    </script>
 </head>
 <body itemscope itemtype="http://schema.org/EmailMessage">
     <table class="body-wrap">


### PR DESCRIPTION
I wanted to implement https://developers.google.com/gmail/markup/reference/one-click-action#confirm_action, but I can't know if it will work.

I guess Gmail only shows actions for some selected senders, right? I couldn't get information on this. Maybe Formspree already applies. Anyway, it would be a nice thing to have, and we just have to include these JSON-LD attributes, everything else is already in place.