### PR TITLE
removing ajax creation for non gold accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Add this "honeypot" field to avoid spam by fooling scrapers. If a value is provi
 
 ### Using AJAX
 
-You can use Formspree via AJAX. This even works cross-origin. The trick is to set the Accept header to application/json. If you're using jQuery this can be done like so:
+Formspree Gold users can submit forms via AJAX. This even works cross-origin. The trick is to set the Accept header to application/json. If you're using jQuery this can be done like so:
 
 ```javascript
 $.ajax({
-    url: "https://formspree.io/you@email.com",
+    url: "https://formspree.io/FORM_ID",
     method: "POST",
     data: {message: "hello!"},
     dataType: "json"

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -157,11 +157,9 @@ def send(email_or_string):
 
         # or create it if it doesn't exist
         if not form:
-
             if request_wants_json():
                 # Can't create a new ajax form unless from the dashboard
                 return jsonerror(400, {'error': "Only Gold accounts may create AJAX forms."})
-
             elif url_domain(settings.SERVICE_URL) in host:
                 # Bad user is trying to submit a form spoofing formspree.io
                 g.log.info('User attempting to create new form spoofing SERVICE_URL. Ignoring.')
@@ -169,11 +167,11 @@ def send(email_or_string):
                     'error.html',
                     title='Unable to submit form',
                     text='Sorry'), 400
-
             else:
+                # all good, create form
                 form = Form(email, host)
 
-        # Check if it has been assigned about using AJAX or not
+        # Check if it has been assigned using AJAX or not
         assign_ajax(form, request_wants_json())
 
         if form.disabled:

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -157,19 +157,21 @@ def send(email_or_string):
 
         # or create it if it doesn't exist
         if not form:
-            if not url_domain(settings.SERVICE_URL) in host:
-                form = Form(email, host)
-            else:
-                # Bad user is trying to submit a form spoofing formspree.io
-                # Error out silently
-                if request_wants_json():
-                    return jsonerror(400, {'error': "Unable to submit form"})
-                else:
-                    return render_template(
-                        'error.html',
-                        title='Unable to submit form',
-                        text='Sorry'), 400
 
+            if request_wants_json():
+                # Can't create a new ajax form unless from the dashboard
+                return jsonerror(400, {'error': "Only Gold accounts may create AJAX forms."})
+
+            elif url_domain(settings.SERVICE_URL) in host:
+                # Bad user is trying to submit a form spoofing formspree.io
+                g.log.info('User attempting to create new form spoofing SERVICE_URL. Ignoring.')
+                return render_template(
+                    'error.html',
+                    title='Unable to submit form',
+                    text='Sorry'), 400
+
+            else:
+                form = Form(email, host)
 
         # Check if it has been assigned about using AJAX or not
         assign_ajax(form, request_wants_json())

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -81,7 +81,7 @@
       <div class="container block">
             <div class="col-1-2">
                 <div class="card">
-                    <h4>Who are you guys?</h4>
+                    <h4>Who are you people?</h4>
                     <p>We're a community of developers that work together to create products. You can contribute on <a href="https://github.com/formspree/formspree">GitHub</a>. {{config.SERVICE_NAME}} is a project that solves a problem many of us have faced: easily adding forms to otherwise static HTML pages.</p>
             	</div>
             </div>
@@ -204,21 +204,6 @@
             </div>
       </div>
 
-      <div class="container narrow block">
-            <div class="col-1-1">
-                <h4>Using AJAX</h4>
-                <p>You can use {{config.SERVICE_NAME}} via AJAX. This even works cross-origin. The trick is to set the <span class="code">Accept</span> header to <span class="code">application/json</span>. If you're using jQuery this can be done like so:
-                <p class="card code">
-                  $.ajax({<br/>
-                  &nbsp;&nbsp;&nbsp;&nbsp;url: "{{config.API_ROOT}}/you@email.com", <br/>
-                  &nbsp;&nbsp;&nbsp;&nbsp;method: "POST",<br />
-                  &nbsp;&nbsp;&nbsp;&nbsp;data: {message: "hello!"},<br />
-                  &nbsp;&nbsp;&nbsp;&nbsp;<span class="tooltip hint--top" data-hint="Required to set the Accept header">dataType: "json"</span><br />
-                  });
-                </p>
-            </div>
-      </div>
-
 <!--
       <div class="container narrow block">
             <div class="col-1-1">
@@ -267,6 +252,29 @@
 
       <div class="container narrow block">
             <div class="col-1-1">
+                <h3>Access to submissions archive</h3>
+                <p>If you ever missed a submission email, for any reason, you can just login and read your last 1000 submissions, all listed and timestamped with full data. Also, the submissions can be exported to CSV or JSON!</p>
+                <p>It even works for submissions made while you were not a {{ config.UPGRADED_PLAN_NAME }} user (the last 100, in this case).</p>
+            </div>
+      </div>
+
+      <div class="container narrow block">
+            <div class="col-1-1">
+                <h3>AJAX Forms</h3>
+                <p>{{config.SERVICE_NAME}} {{ config.UPGRADED_PLAN_NAME }} users can use AJAX to submit forms. This even works cross-origin. First create a new form in your account dashboard. Then set the <span class="code">Accept</span> header on your form to <span class="code">application/json</span>. If you're using jQuery this can be done like so:
+                <p class="card code">
+                  $.ajax({<br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;url: "{{config.API_ROOT}}/FORM_ID", <br/>
+                  &nbsp;&nbsp;&nbsp;&nbsp;method: "POST",<br />
+                  &nbsp;&nbsp;&nbsp;&nbsp;data: {message: "hello!"},<br />
+                  &nbsp;&nbsp;&nbsp;&nbsp;<span class="tooltip hint--top" data-hint="Required to set the Accept header">dataType: "json"</span><br />
+                  });
+                </p>
+            </div>
+      </div>
+
+      <div class="container narrow block">
+            <div class="col-1-1">
                 <h3>Same form on multiple pages</h3>
                 <p>Showing the same form on many different pages? Generate a form verified site-wide and don't worry about having to track multiple confirmation emails.</p>
             </div>
@@ -285,14 +293,6 @@
                 <p>Don't want your users to complete a reCAPTCHA? Each form now comes with the option to disable the reCAPTCHA, so you can maintain complete control over your form. You can even keep reCAPTCHA on a few forms that might be suceptible to spam, while disabling it on others.</p>
             </div>
         </div>
-
-      <div class="container narrow block">
-            <div class="col-1-1">
-                <h3>Access to submissions archive</h3>
-                <p>If you ever missed a submission email, for any reason, you can just login and read your last 1000 submissions, all listed and timestamped with full data. Also, the submissions can be exported to CSV or JSON!</p>
-                <p>It even works for submissions made while you were not a {{ config.UPGRADED_PLAN_NAME }} user (the last 100, in this case).</p>
-            </div>
-      </div>
 
   </div>
 

--- a/formspree/templates/users/account.html
+++ b/formspree/templates/users/account.html
@@ -62,6 +62,7 @@
               <li>Unlimited submissions</li>
               <li>Access to submission archives</li>
               <li>Ability to hide your email from your page's HTML and replace it with a random-like URL</li>
+              <li>Ability to submit AJAX forms</li>
               <li>Ability to create forms linked to other email accounts</li>
             </ol>
 

--- a/tests/test_form_posts.py
+++ b/tests/test_form_posts.py
@@ -7,11 +7,9 @@ from formspree.users.models import User, Email
 
 from formspree_test_case import FormspreeTestCase
 
-ajax_headers = {
-    'Referer': 'testwebsite.com',
-    'X_REQUESTED_WITH': 'xmlhttprequest'
+http_headers = {
+    'Referer': 'example.com'
 }
-
 
 class FormPostsTestCase(FormspreeTestCase):
 
@@ -23,7 +21,7 @@ class FormPostsTestCase(FormspreeTestCase):
     def test_submit_form(self):
         httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
         self.client.post('/alice@testwebsite.com',
-            headers=ajax_headers,
+            headers=http_headers,
             data={'name': 'alice', '_subject': 'my-nice-subject'}
         )
         self.assertEqual(1, Form.query.count())
@@ -32,7 +30,7 @@ class FormPostsTestCase(FormspreeTestCase):
 
         httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
         self.client.post('/alice@testwebsite.com',
-            headers=ajax_headers,
+            headers=http_headers,
             data={'name': 'alice',
                   '_subject': 'my-nice-subject',
                   '_format': 'plain'}
@@ -47,7 +45,7 @@ class FormPostsTestCase(FormspreeTestCase):
         httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
         httpretty.reset()
 
-        no_referer = ajax_headers.copy()
+        no_referer = http_headers.copy()
         del no_referer['Referer']
         r = self.client.post('/bob@testwebsite.com',
             headers = no_referer,
@@ -128,11 +126,24 @@ class FormPostsTestCase(FormspreeTestCase):
         self.assertEqual(400, r.status_code)
         self.assertEqual(0, Form.query.first().counter)
 
-    @httpretty.activate
+    def test_fail_ajax_form(self):
+        httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
+        httpretty.reset()
+
+        ajax_headers = http_headers.copy()
+        ajax_headers['X_REQUESTED_WITH'] = 'xmlhttprequest'
+        r = self.client.post('/bob@example.com',
+            headers = ajax_headers,
+            data={'name': 'bob'}
+        )
+        self.assertEqual(False, httpretty.has_request())
+        self.assertNotEqual(200, r.status_code)
+
+    @httpretty.activate    
     def test_activation_workflow(self):
         httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
         r = self.client.post('/bob@testwebsite.com',
-            headers=ajax_headers,
+            headers=http_headers,
             data={'name': 'bob'}
         )
         f = Form.query.first()
@@ -145,7 +156,7 @@ class FormPostsTestCase(FormspreeTestCase):
 
         # form has another submission, number of forms in the table should increase?
         r = self.client.post('/bob@testwebsite.com',
-            headers=ajax_headers,
+            headers=http_headers,
             data={'name': 'bob'}
         )
         number_of_forms = Form.query.count()
@@ -169,7 +180,7 @@ class FormPostsTestCase(FormspreeTestCase):
 
         # a third submission should now increase the counter
         r = self.client.post('/bob@testwebsite.com',
-            headers=ajax_headers,
+            headers=http_headers,
             data={'name': 'bob'}
         )
         number_of_forms = Form.query.count()
@@ -190,9 +201,9 @@ class FormPostsTestCase(FormspreeTestCase):
         # monthly limit is set to 2 during tests
         self.assertEqual(settings.MONTHLY_SUBMISSIONS_LIMIT, 2)
 
-        # manually verify luke@testwebsite.com
+        # manually verify luke@example.com
         r = self.client.post('/luke@testwebsite.com',
-            headers=ajax_headers,
+            headers=http_headers,
             data={'name': 'luke'}
         )
         f = Form.query.first()
@@ -204,28 +215,28 @@ class FormPostsTestCase(FormspreeTestCase):
         # first submission
         httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
         r = self.client.post('/luke@testwebsite.com',
-            headers=ajax_headers,
+            headers=http_headers,
             data={'name': 'peter'}
         )
-        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.status_code, 302)
         self.assertIn('peter', httpretty.last_request().body)
 
         # second submission
         httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
         r = self.client.post('/luke@testwebsite.com',
-            headers=ajax_headers,
+            headers=http_headers,
             data={'name': 'ana'}
         )
-        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.status_code, 302)
         self.assertIn('ana', httpretty.last_request().body)
 
         # third submission, now we're over the limit
         httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
         r = self.client.post('/luke@testwebsite.com',
-            headers=ajax_headers,
+            headers=http_headers,
             data={'name': 'maria'}
         )
-        self.assertEqual(r.status_code, 200) # the response to the user is the same
+        self.assertEqual(r.status_code, 302) # the response to the user is the same
                                              # being the form over the limits or not
 
         # but the mocked sendgrid should never receive this last form
@@ -252,17 +263,17 @@ class FormPostsTestCase(FormspreeTestCase):
         # the user should receive form posts again
         httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
         r = self.client.post('/luke@testwebsite.com',
-            headers=ajax_headers,
+            headers=http_headers,
             data={'name': 'noah'}
         )
-        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.status_code, 302)
         self.assertIn('noah', httpretty.last_request().body)
 
     @httpretty.activate
     def test_first_submission_is_stored(self):
         httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
         r = self.client.post('/what@firstsubmissed.com',
-            headers=ajax_headers,
+            headers=http_headers,
             data={'missed': 'this was important'}
         )
         f = Form.query.first()

--- a/tests/test_form_posts.py
+++ b/tests/test_form_posts.py
@@ -8,7 +8,7 @@ from formspree.users.models import User, Email
 from formspree_test_case import FormspreeTestCase
 
 http_headers = {
-    'Referer': 'example.com'
+    'Referer': 'testwebsite.com'
 }
 
 class FormPostsTestCase(FormspreeTestCase):
@@ -91,7 +91,7 @@ class FormPostsTestCase(FormspreeTestCase):
         self.assertEqual(302, r.status_code)
         self.assertEqual(0, Form.query.first().counter)
 
-    @httpretty.activate    
+    @httpretty.activate
     def test_fail_with_invalid_reply_to(self):
         httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
 
@@ -126,6 +126,7 @@ class FormPostsTestCase(FormspreeTestCase):
         self.assertEqual(400, r.status_code)
         self.assertEqual(0, Form.query.first().counter)
 
+    @httpretty.activate    
     def test_fail_ajax_form(self):
         httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
         httpretty.reset()


### PR DESCRIPTION
**Changes proposed in this pull request:**

* Currently we're seeing a lot of spam come from ajax forms, since we must allow ajax to bypass the CAPTCHA. Unfortunately the most strait forward solution is to remove this capability.
* This PR makes submitting AJAX forms a gold feature.
* Existing forms will continue to work, even AJAX forms that have been created by non gold users.

**Have you made sure to add:**
- [X] Tests
- [x] Documentation
