### PR TITLE
Stop storing useless keys.

### DIFF
--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -15,7 +15,10 @@ CAPTCHA_URL = 'https://www.google.com/recaptcha/api/siteverify'
 CAPTCHA_VAL = 'g-recaptcha-response'
 
 HASH = lambda x, y: hashlib.md5(x.encode('utf-8')+y.encode('utf-8')+settings.NONCE_SECRET).hexdigest()
-EXCLUDE_KEYS = {'_gotcha', '_next', '_subject', '_cc', '_format', CAPTCHA_VAL, '_host_nonce', '_language'}
+
+KEYS_NOT_STORED = {'_gotcha', '_format', '_language', CAPTCHA_VAL, '_host_nonce'}
+KEYS_EXCLUDED_FROM_EMAIL = KEYS_NOT_STORED.union({'_subject', '_cc', '_next'})
+
 REDIS_COUNTER_KEY = 'monthly_{form_id}_{month}'.format
 REDIS_HOSTNAME_KEY = 'hostname_{nonce}'.format
 REDIS_FIRSTSUBMISSION_KEY = 'first_{nonce}'.format

--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -12,7 +12,8 @@ from werkzeug.datastructures import ImmutableMultiDict, \
                                     ImmutableOrderedMultiDict
 from helpers import HASH, HASHIDS_CODEC, REDIS_COUNTER_KEY, \
                     http_form_to_dict, referrer_to_path, \
-                    store_first_submission, fetch_first_submission
+                    store_first_submission, fetch_first_submission, \
+                    KEYS_NOT_STORED
 
 
 class Form(DB.Model):
@@ -158,7 +159,7 @@ class Form(DB.Model):
 
         # archive the form contents
         sub = Submission(self.id)
-        sub.data = data
+        sub.data = {key: data[key] for key in data if key not in KEYS_NOT_STORED}
         DB.session.add(sub)
 
         # commit changes

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -18,7 +18,8 @@ from formspree.utils import request_wants_json, jsonerror, IS_VALID_EMAIL, \
 from helpers import http_form_to_dict, ordered_storage, referrer_to_path, \
                     remove_www, referrer_to_baseurl, sitewide_file_check, \
                     verify_captcha, temp_store_hostname, get_temp_hostname, \
-                    HASH, EXCLUDE_KEYS, assign_ajax, valid_domain_request
+                    HASH, assign_ajax, valid_domain_request, \
+                    KEYS_NOT_STORED, KEYS_EXCLUDED_FROM_EMAIL
 from models import Form, Submission
 
 from jinja2.exceptions import TemplateNotFound
@@ -59,7 +60,7 @@ def send(email_or_string):
         received_data = request.get_json() or {}
         sorted_keys = received_data.keys()
 
-    sorted_keys = [k for k in sorted_keys if k not in EXCLUDE_KEYS]
+    sorted_keys = [k for k in sorted_keys if k not in KEYS_EXCLUDED_FROM_EMAIL]
 
     # NOTE: host in this function generally refers to the referrer hostname.
 
@@ -543,7 +544,7 @@ def form_submissions(hashid, format=None):
             fields = set()
             for s in form.submissions:
                 fields.update(s.data.keys())
-            fields -= EXCLUDE_KEYS
+            fields -= KEYS_NOT_STORED
 
             submissions = []
             for sub in form.submissions:


### PR DESCRIPTION
**Changes proposed in this pull request:**

* Stop storing all the keys in `KEYS_NOT_STORED` that are being currently stored in the `submissions` table.
* Start showing `'_subject'`, `'_cc'` and  `'_next'` in the submissions list on the dashboard, as they may contain useful information for the form owner (do they? I'm personally using `_subject` in one of my forms as the field where the submitter writes his name) -- they still won't be sent in the submission email.