### PR TITLE
List-Unsubscribe headers and unconditional form unconfirmation endpoint.

### DIFF
--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -6,7 +6,8 @@ import pyaml
 import io
 
 from flask import request, url_for, render_template, redirect, \
-                  jsonify, flash, make_response, Response, g
+                  jsonify, flash, make_response, Response, g, \
+                  abort
 from flask.ext.login import current_user, login_required
 from flask.ext.cors import cross_origin
 from urlparse import urljoin
@@ -371,6 +372,18 @@ def unblock_email(email):
 
     elif request.method == 'GET':
         return render_template('forms/unblock_email.html', email=email), 200
+
+
+def unconfirm_form(form_id, digest):
+    '''
+    We send a digest as the List-Unsubscribe header on every submission.
+    Here we get that digest and handle the unconfirmation request.
+    '''
+    form = Form.query.get(form_id)
+    if form.unconfirm_with_digest(digest):
+        return '', 200
+    else:
+        return abort(401)
 
 
 def confirm_email(nonce):

--- a/formspree/routes.py
+++ b/formspree/routes.py
@@ -12,6 +12,7 @@ def configure_routes(app):
     app.add_url_rule('/unblock/<email>', 'unblock_email', view_func=forms.views.unblock_email, methods=['GET', 'POST'])
     app.add_url_rule('/resend/<email>', 'resend_confirmation', view_func=forms.views.resend_confirmation, methods=['POST'])
     app.add_url_rule('/confirm/<nonce>', 'confirm_email', view_func=forms.views.confirm_email, methods=['GET'])
+    app.add_url_rule('/unconfirm/<digest>/<form_id>', 'unconfirm_form', view_func=forms.views.unconfirm_form, methods=['POST'])
     app.add_url_rule('/thanks', 'thanks', view_func=forms.views.thanks, methods=['GET'])
 
     # Users

--- a/formspree/utils.py
+++ b/formspree/utils.py
@@ -3,6 +3,7 @@ import datetime
 import calendar
 import urlparse
 import uuid
+import json
 import re
 from flask import request, url_for, jsonify, g
 
@@ -117,7 +118,7 @@ def next_url(referrer=None, next=None):
 
 
 def send_email(to=None, subject=None, text=None, html=None,
-               sender=None, cc=None, reply_to=None):
+               sender=None, cc=None, reply_to=None, headers=None):
     g.log = g.log.new(to=to, sender=sender)
 
     if None in [to, subject, text, sender]:
@@ -140,6 +141,9 @@ def send_email(to=None, subject=None, text=None, html=None,
         })
     except ValueError:
         data.update({'from': sender})
+
+    if headers:
+        data.update({'headers': json.dumps(headers)})
 
     if reply_to:
         data.update({'replyto': reply_to})

--- a/tests/test_list_unsubscribe.py
+++ b/tests/test_list_unsubscribe.py
@@ -1,0 +1,45 @@
+import httpretty
+import urllib2
+import json
+import re
+
+from formspree.forms.models import Form
+from formspree import settings
+from formspree.app import DB
+
+from formspree_test_case import FormspreeTestCase
+
+class ListUnsubscribeTestCase(FormspreeTestCase):
+
+    @httpretty.activate
+    def test_list_unsubscribe(self):
+        httpretty.register_uri(httpretty.POST, 'https://api.sendgrid.com/api/mail.send.json')
+
+        r = self.client.post('/bob@testwebsite.com',
+            headers = {'Referer': 'http://testwebsite.com'},
+            data={'name': 'bob'}
+        )
+        f = Form.query.first()
+        f.confirm_sent = True
+        f.confirmed = True
+        DB.session.add(f)
+        DB.session.commit()
+
+        r = self.client.post('/bob@testwebsite.com',
+            headers = {'Referer': 'http://testwebsite.com'},
+            data={'name': 'carol'}
+        )
+
+        self.assertEqual(r.status_code, 302)
+        body = urllib2.unquote(httpretty.last_request().body)
+        print(body)
+        res = re.search('"List-Unsubscribe":[^"]*"<([^>]+)>"', body)
+        self.assertTrue(res is not None)
+
+        url = res.group(1)
+        r = self.client.post(url)
+        self.assert200(r)
+
+        f = Form.query.first()
+        self.assertEqual(f.confirm_sent, True)
+        self.assertEqual(f.confirmed, False)


### PR DESCRIPTION
In order to make [Gmail actions](https://github.com/formspree/formspree/pull/171) work we [must](https://support.google.com/mail/answer/81126?hl=en) implement this [List-Unsubscribe](https://www.ietf.org/rfc/rfc2369.txt) thing.

It would actually be a good thing, if it worked as intended (Gmail showing a special "unsubscribe" link, only visible to the first recipient of our email).

Even if it doesn't work, I believe it will do no harm. Email headers are not redirected when someone forwards or replies to an email, so there isn't a problem of third-parties unconfirming a form on behalf of some Formspree user. Also, exposing an `/unconfirm/<digest>/<form_id>` endpoint isn't a problem if the user doesn't know the digest.

I may be missing something. Please let me know.