### PR TITLE
Hiding missed username when logging in

### DIFF
--- a/formspree/users/views.py
+++ b/formspree/users/views.py
@@ -124,12 +124,8 @@ def login():
     email = request.form['email'].lower().strip()
     password = request.form['password']
     user = User.query.filter_by(email=email).first()
-    if user is None:
-        flash(u"We couldn't find an account related with this email. "
-              "Please verify the email entered.", "warning")
-        return redirect(url_for('login'))
-    elif not check_password(user.password, password):
-        flash(u"Invalid Password. Please verify the password entered.",
+    if user is None or not check_password(user.password, password):
+        flash(u"Invalid username or password.",
               'warning')
         return redirect(url_for('login'))
     login_user(user, remember=True)

--- a/formspree/users/views.py
+++ b/formspree/users/views.py
@@ -144,15 +144,11 @@ def forgot_password():
     elif request.method == 'POST':
         email = request.form['email'].lower().strip()
         user = User.query.filter_by(email=email).first()
-        if not user:
-            return render_template('error.html', title='Not registered', text="We couldn't find an account associated with this email address.</p><p>Remember that you must use the primary email address you used to register the account, it can't be any other address you have confirmed later.")
-
-        if user.send_password_reset():
+        if not user or user.send_password_reset():
             return render_template(
                 'info.html',
                 title='Reset email sent',
-                text=u"We've sent a link to {addr}. Click on the link to be "
-                     "prompted to a new password.".format(addr=user.email)
+                text=u"We've sent you a password reset link. Please check your email."
             )
         else:
             flash(u"Something is wrong, please report this to us.", 'error')


### PR DESCRIPTION
**Changes proposed in this pull request:**

* Previously when a user loged in, if they mistyped their email, it would give them an error. This has been replaced by a generic "username or password" error.
* Previously if a user tried to reset their password, and supplied an incorrect email, they would be notified that the email wasn't in the system. This has been replaced with a generic "check your inbox" message.
* Overall revealing whether an email is in our system provides hackers with more information that they can use to gain unauthorized access.

**Have you made sure to add:**
- [ ] Tests
- [ ] Documentation

**Screenshots and GIFs**

![screen shot 2018-03-11 at 6 26 48 pm](https://user-images.githubusercontent.com/409293/37259357-8d0355d2-255b-11e8-8044-e9db8d410d8e.png)

**Deploy notes**

[Put any changes necessary in order to deploy (such as DB migrations)]

**Any Additional Information**