### PR TITLE
Repel bots on unconfirm URL.

### DIFF
--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -383,6 +383,11 @@ def request_unconfirm_form(form_id):
     This endpoints triggers a confirmation email that directs users to the
     GET version of unconfirm_form.
     '''
+
+    # repel bots
+    if not request.user_agent.browser:
+        return ''
+
     form = Form.query.get(form_id)
 
     unconfirm_url = url_for(

--- a/tests/test_unsubscribe.py
+++ b/tests/test_unsubscribe.py
@@ -32,6 +32,12 @@ def test_unconfirm_process(client, msend):
 
     # this should send a confirmation email
     r = client.get(request_unconfirm_url)
+
+    # actually, it should fail unless the request comes from a browser
+    assert not msend.called
+
+    # now it must work
+    r = client.get(request_unconfirm_url, headers={'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:62.0) Gecko/20100101 Firefox/62.0'})
     assert r.status_code == 200
     assert msend.called
 


### PR DESCRIPTION
Tries to fix the problem of users with email antivirus that open their URLs (also known as NSA malwares) getting unconfirmation emails along with each submission.