### PR TITLE
only allow "invisible email" forms for paying users.

### DIFF
--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -99,7 +99,16 @@ def send(email_or_string):
         form = Form.get_with_hashid(hashid)
 
         if form:
-            # Check if it has been assigned about using AJAX or not
+            # forms addressed by their hashids are only allowed for paying users
+            if not form.has_feature('invisible'):
+                if request_wants_json():
+                    return jsonerror(403, {'error': 'Form unavailable at this address.'})
+                else:
+                    return render_template('error.html',
+                                           title='Form unavailable at this address',
+                                           text=f'The form at <span class="code">https://formspree.io/{form.hashid}</span> is only available for Formspree Gold, try resubmitting to <span class="code">https://formspree.io/{form.email}</span>.'), 403
+
+            # check if it has been assigned about using AJAX or not
             assign_ajax(form, request_wants_json())
 
             if form.disabled:

--- a/formspree/users/models.py
+++ b/formspree/users/models.py
@@ -17,8 +17,8 @@ class Plan(DB.Enum):
 
     plan_features = {
         'v1_free': set(),
-        'v1_gold': {'dashboard', 'unlimited'},
-        'v1_platinum': {'dashboard', 'unlimited', 'whitelabel'}
+        'v1_gold': {'invisible', 'dashboard', 'unlimited'},
+        'v1_platinum': {'invisible', 'dashboard', 'unlimited', 'whitelabel'}
     }
 
     @classmethod


### PR DESCRIPTION
This fixes the bug that allowed ex-Gold users to keep using their invisible-email forms long after they stopped being Gold.

**Changes proposed in this pull request:**

* Introduce the `invisible` feature in the plans.
* Check if the submitted `form` is a Gold form for each submission to a `/<hashid>` endpoint (not `/<email>`) and disallow that for forms without the `invisible` feature.

**Have you made sure to add:**
- [ ] Tests
- [ ] Documentation

**Deploy notes**

Nothing is needed.