### PR TITLE
Update URL to the new Formspree Test Area

### DIFF
--- a/formspree/templates/layouts/base.html
+++ b/formspree/templates/layouts/base.html
@@ -68,7 +68,7 @@
     {% else %}
       <div class="greetings">
         <h4 class="light">
-          <a href="http://testformspree.com/" target="_blank">Try Formspree!</a>
+          <a href="https://test.formspree.io/" target="_blank">Try Formspree!</a>
         </h4>
       </div>
       <div class="menu">

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -28,7 +28,7 @@
                     &nbsp;&nbsp;&nbsp;&nbsp;<span class="tooltip hint--bottom" data-hint="When user submits, we'll email data to you">&lt;input type="<span class="attr">submit</span>" value="<span class="attr">Send</span>"&gt;</span><br />
                     &lt;/form&gt;
                 </p>
-                <a href="http://testformspree.com/" target="_blank">Test it out now with your email!</a>
+                <a href="https://test.formspree.io/" target="_blank">Test it out now with your email!</a>
             </div>
       </div>
   </div>
@@ -310,7 +310,7 @@
       <div class="container narrow block">
           <div class="col-1-2">
             <p>If you have a problem, please look <a href="http://help.formspree.io/">here</a> first. To sign up for our newsletter, use the form on the right.</p>
-            <p>For a quick demo of Formspree, <a href="http://testformspree.com/" target="_blank">click here</a>.</p>
+            <p>For a quick demo of Formspree, <a href="https://test.formspree.io/" target="_blank">click here</a>.</p>
           </div>
           <div class="col-1-2">
             <form method="POST" action="{{config.API_ROOT}}/{{config.NEWSLETTER_EMAIL}}">

--- a/formspree/templates/users/dashboard.html
+++ b/formspree/templates/users/dashboard.html
@@ -35,7 +35,7 @@
       {% else %}
         <div class="col-1-2">
           <p>If you have a problem, please look <a href="http://help.formspree.io/">here</a> first. To sign up for our newsletter, use the form on the right.</p>
-          <p>For a quick demo of Formspree, <a href="http://testformspree.com/" target="_blank">click here</a>.</p>
+          <p>For a quick demo of Formspree, <a href="https://test.formspree.io/" target="_blank">click here</a>.</p>
         </div>
         <div class="col-1-2">
           <form method="POST" action="{{config.API_ROOT}}/{{config.NEWSLETTER_EMAIL}}">


### PR DESCRIPTION
**Changes proposed in this pull request:**

* Update URL to the new Formspree Test Area

**Have you made sure to add:**
- [ ] Tests
- [ ] Documentation

**Screenshots and GIFs**
Old URL leads to a GitHub 404-Page.
![image](https://user-images.githubusercontent.com/25749360/49043487-82ce1880-f1cb-11e8-831a-51943e06d10c.png)
New URL leads to the (current?) Formspree Test Area
![image](https://user-images.githubusercontent.com/25749360/49043504-9aa59c80-f1cb-11e8-84d4-91e4e4ff4b09.png)
