### PR TITLE
a tags for Attached Files in plain_form template

### DIFF
--- a/formspree/templates/email/plain_form.html
+++ b/formspree/templates/email/plain_form.html
@@ -8,6 +8,16 @@
 
 <table border="0" width="100%">
     {% for k in keys %}
+        {% if k == "Attached File" %}
+          <tr>
+            <td align="right" valign="top" width="70" style="padding: 5px 5px 5px 0;"><strong>{{ k }}:</strong> </td>
+            <td align="left" valign="top" width="*" style="padding: 5px 5px 5px;">
+            {% for item in data.get(k) %}
+                <pre style="margin: 0; font-family: inherit; white-space: pre-wrap;"><a href="{{ item }}">{{ item }}</a></pre>
+            {% endfor %}          
+            </td>
+          </tr>
+        {% endif %}
         <tr>
             <td align="right" valign="top" width="70" style="padding: 5px 5px 5px 0;"><strong>{{k}}:</strong> </td>
             <td align="left" valign="top" width="*" style="padding: 5px 5px 5px;">


### PR DESCRIPTION
This assumes (which seems to be the case) that Attached File key is always in an array format. 

Otherwise we can check if data.get(k) is an array with 

{% if data.get(k) | array %}

And run an else statement like

```
{% if k == "Attached File" %}
  <tr>
    <td align="right" valign="top" width="70" style="padding: 5px 5px 5px 0;"><strong>{{ k }}:</strong> </td>
    <td align="left" valign="top" width="*" style="padding: 5px 5px 5px;">
      {% if data.get(k) | array %}
        {% for item in data.get(k) %}
          <pre style="margin: 0; font-family: inherit; white-space: pre-wrap;"><a href="{{ item }}">{{ item }}</a></pre>
        {% endfor %}
      {% else %}
        <pre style="margin: 0; font-family: inherit; white-space: pre-wrap;"><a href="{{ data.get(k, '') }}">{{ data.get(k,'') }}</a></pre>
      {% endif %}
    </td>
  </tr>
{% endif %}
```
